### PR TITLE
Add colour to posts

### DIFF
--- a/apps/admin/core/container/persistence.rb
+++ b/apps/admin/core/container/persistence.rb
@@ -1,4 +1,5 @@
 require "admin/persistence/uniqueness_check"
+require "admin/persistence/post_color_picker"
 
 Admin::Container.namespace "admin.persistence" do |container|
   container.register "user_email_uniqueness_check" do
@@ -12,6 +13,13 @@ Admin::Container.namespace "admin.persistence" do |container|
     Admin::Persistence::UniquenessCheck.new(
       container["core.persistence.rom"].relation(:posts),
       :slug
+    )
+  end
+
+  container.register "post_color_picker" do
+    Admin::Persistence::PostColorPicker.new(
+      Types::Color,
+      container["admin.persistence.repositories.posts"].method(:recent_colors)
     )
   end
 end

--- a/apps/admin/core/container/persistence.rb
+++ b/apps/admin/core/container/persistence.rb
@@ -18,7 +18,7 @@ Admin::Container.namespace "admin.persistence" do |container|
 
   container.register "post_color_picker" do
     Admin::Persistence::PostColorPicker.new(
-      Types::Color,
+      Types::PostHighlightColor,
       container["admin.persistence.repositories.posts"].method(:recent_colors)
     )
   end

--- a/apps/admin/lib/admin/entities/post.rb
+++ b/apps/admin/lib/admin/entities/post.rb
@@ -14,6 +14,7 @@ module Admin
       attribute :status, Status
       attribute :author_id, Types::Strict::Int
       attribute :published_at, Types::Time
+      attribute :color, Types::Strict::String
 
       def deleted?
         status == "deleted"

--- a/apps/admin/lib/admin/entities/post.rb
+++ b/apps/admin/lib/admin/entities/post.rb
@@ -14,6 +14,7 @@ module Admin
       attribute :status, Status
       attribute :author_id, Types::Strict::Int
       attribute :published_at, Types::Time
+      attribute :colour, Types::Colour
 
       def deleted?
         status == "deleted"

--- a/apps/admin/lib/admin/entities/post.rb
+++ b/apps/admin/lib/admin/entities/post.rb
@@ -14,7 +14,6 @@ module Admin
       attribute :status, Status
       attribute :author_id, Types::Strict::Int
       attribute :published_at, Types::Time
-      attribute :colour, Types::Colour
 
       def deleted?
         status == "deleted"

--- a/apps/admin/lib/admin/entities/post.rb
+++ b/apps/admin/lib/admin/entities/post.rb
@@ -14,7 +14,7 @@ module Admin
       attribute :status, Status
       attribute :author_id, Types::Strict::Int
       attribute :published_at, Types::Time
-      attribute :color, Types::Strict::String
+      attribute :color, Types::PostHighlightColor
 
       def deleted?
         status == "deleted"

--- a/apps/admin/lib/admin/persistence/post_color_picker.rb
+++ b/apps/admin/lib/admin/persistence/post_color_picker.rb
@@ -1,0 +1,17 @@
+module Admin
+  module Persistence
+    class PostColorPicker
+      attr_reader :colors, :recently_used_color_finder
+
+      def initialize(colors, recently_used_color_finder)
+        @colors = colors
+        @recently_used_color_finder = recently_used_color_finder
+      end
+
+      def call
+        recent_colors = recently_used_color_finder.().uniq
+        (colors.values - recent_colors).sample(1).first
+      end
+    end
+  end
+end

--- a/apps/admin/lib/admin/persistence/repositories/posts.rb
+++ b/apps/admin/lib/admin/persistence/repositories/posts.rb
@@ -36,9 +36,9 @@ module Admin
         def recent_colors
           posts
             .select(:color)
-            .order(:created_at)
+            .order(Sequel.desc(:created_at))
             .limit(5)
-            .to_a
+            .map{ |p| p[:color] }
         end
       end
     end

--- a/apps/admin/lib/admin/persistence/repositories/posts.rb
+++ b/apps/admin/lib/admin/persistence/repositories/posts.rb
@@ -32,6 +32,14 @@ module Admin
             .order(Sequel.desc(:created_at))
             .as(Entities::Post)
         end
+
+        def recent_colors
+          posts
+            .select(:color)
+            .order(:created_at)
+            .limit(5)
+            .to_a
+        end
       end
     end
   end

--- a/apps/admin/lib/admin/posts/forms/create_form.rb
+++ b/apps/admin/lib/admin/posts/forms/create_form.rb
@@ -12,18 +12,22 @@ module Admin
         prefix :post
 
         define do
-          text_field :title, label: "Title"
-          text_field :teaser, label: "Teaser"
-          text_area :body, label: "Body"
-          selection_field :author_id, label: "Author", options: dep(:author_list)
-          select_box :colour,
-            label: "Colour",
-            selector_label: "Choose colour",
-            options: dep(:colour_list)
-          multi_selection_field :post_categories,
-            label: "Categories",
-            selector_label: "Choose categories",
-            options: dep(:categories_list)
+          section :post do
+            group do
+              text_field :title, label: "Title"
+            end
+            group do
+              text_area :teaser, label: "Teaser"
+              selection_field :author_id, label: "Author", options: dep(:author_list)
+            end
+
+            text_area :body, label: "Body"
+
+            multi_selection_field :post_categories,
+              label: "Categories",
+              selector_label: "Choose categories",
+              options: dep(:categories_list)
+          end
         end
 
         def author_list

--- a/apps/admin/lib/admin/posts/forms/create_form.rb
+++ b/apps/admin/lib/admin/posts/forms/create_form.rb
@@ -43,10 +43,6 @@ module Admin
             }
           }
         end
-
-        def colour_list
-          Types::Colour.values.map { |value| [value, value.capitalize] }
-        end
       end
     end
   end

--- a/apps/admin/lib/admin/posts/forms/create_form.rb
+++ b/apps/admin/lib/admin/posts/forms/create_form.rb
@@ -16,6 +16,10 @@ module Admin
           text_field :teaser, label: "Teaser"
           text_area :body, label: "Body"
           selection_field :author_id, label: "Author", options: dep(:author_list)
+          select_box :colour,
+            label: "Colour",
+            selector_label: "Choose colour",
+            options: dep(:colour_list)
           multi_selection_field :post_categories,
             label: "Categories",
             selector_label: "Choose categories",
@@ -34,6 +38,10 @@ module Admin
               slug: category.slug
             }
           }
+        end
+
+        def colour_list
+          Types::Colour.values.map { |value| [value, value.capitalize] }
         end
       end
     end

--- a/apps/admin/lib/admin/posts/forms/edit_form.rb
+++ b/apps/admin/lib/admin/posts/forms/edit_form.rb
@@ -19,6 +19,10 @@ module Admin
           selection_field :author_id, label: "Author", options: dep(:author_list)
           select_box :status, label: "Status", options: dep(:status_list)
           date_time_field :published_at, label: "Published at"
+          select_box :colour,
+            label: "Colour",
+            selector_label: "Choose colour",
+            options: dep(:colour_list)
           multi_selection_field :post_categories,
             label: "Categories",
             selector_label: "Choose categories",
@@ -42,6 +46,10 @@ module Admin
               slug: category.slug
             }
           }
+        end
+
+        def colour_list
+          Types::Colour.values.map { |value| [value, value.capitalize] }
         end
       end
     end

--- a/apps/admin/lib/admin/posts/forms/edit_form.rb
+++ b/apps/admin/lib/admin/posts/forms/edit_form.rb
@@ -52,10 +52,6 @@ module Admin
             }
           }
         end
-
-        def colour_list
-          Types::Colour.values.map { |value| [value, value.capitalize] }
-        end
       end
     end
   end

--- a/apps/admin/lib/admin/posts/forms/edit_form.rb
+++ b/apps/admin/lib/admin/posts/forms/edit_form.rb
@@ -12,22 +12,27 @@ module Admin
         prefix :post
 
         define do
-          text_field :title, label: "Title"
-          text_field :teaser, label: "Teaser"
-          text_area :body, label: "Body"
-          text_field :slug, label: "Slug"
-          selection_field :author_id, label: "Author", options: dep(:author_list)
-          select_box :status, label: "Status", options: dep(:status_list)
-          date_time_field :published_at, label: "Published at"
-          select_box :colour,
-            label: "Colour",
-            selector_label: "Choose colour",
-            options: dep(:colour_list)
-          multi_selection_field :post_categories,
-            label: "Categories",
-            selector_label: "Choose categories",
-            options: dep(:categories_list)
+          section :post do
+            group do
+              text_field :title, label: "Title"
+              text_field :slug, label: "Slug"
+            end
+            group do
+              text_area :teaser, label: "Teaser"
+              selection_field :author_id, label: "Author", options: dep(:author_list)
+            end
 
+            text_area :body, label: "Body"
+
+            group do
+              select_box :status, label: "Status", options: dep(:status_list)
+              date_time_field :published_at, label: "Published at"
+            end
+            multi_selection_field :post_categories,
+              label: "Categories",
+              selector_label: "Choose categories",
+              options: dep(:categories_list)
+          end
         end
 
         def author_list

--- a/apps/admin/lib/admin/posts/operations/create.rb
+++ b/apps/admin/lib/admin/posts/operations/create.rb
@@ -10,7 +10,8 @@ module Admin
         include Admin::Import(
           "admin.persistence.repositories.posts",
           "core.persistence.commands.create_post",
-          "admin.slugify"
+          "admin.slugify",
+          "admin.persistence.post_color_picker",
         )
 
         include Dry::ResultMatcher.for(:call)
@@ -30,7 +31,8 @@ module Admin
 
         def prepare_attributes(attributes)
           attributes.merge(
-            slug: slugify.(attributes[:title], posts.method(:slug_exists?))
+            slug: slugify.(attributes[:title], posts.method(:slug_exists?)),
+            color: post_color_picker.()
           )
         end
       end

--- a/apps/admin/lib/admin/posts/validation/form.rb
+++ b/apps/admin/lib/admin/posts/validation/form.rb
@@ -27,7 +27,6 @@ module Admin
         optional(:author_id).filled(:int?)
         optional(:status).filled(included_in?: Entities::Post::Status.values)
         optional(:published_at).maybe(:time?)
-        required(:colour).filled
         rule(published_at: [:status, :published_at]) do |status, published_at|
           status.eql?("published").then(published_at.filled?)
         end

--- a/apps/admin/lib/admin/posts/validation/form.rb
+++ b/apps/admin/lib/admin/posts/validation/form.rb
@@ -23,6 +23,7 @@ module Admin
         optional(:teaser).filled
         optional(:body).filled
         optional(:slug).filled
+        optional(:color).filled
         optional(:previous_slug).maybe
         optional(:author_id).filled(:int?)
         optional(:status).filled(included_in?: Entities::Post::Status.values)

--- a/apps/admin/lib/admin/posts/validation/form.rb
+++ b/apps/admin/lib/admin/posts/validation/form.rb
@@ -27,6 +27,7 @@ module Admin
         optional(:author_id).filled(:int?)
         optional(:status).filled(included_in?: Entities::Post::Status.values)
         optional(:published_at).maybe(:time?)
+        required(:colour).filled
         rule(published_at: [:status, :published_at]) do |status, published_at|
           status.eql?("published").then(published_at.filled?)
         end

--- a/apps/main/lib/main/entities/post.rb
+++ b/apps/main/lib/main/entities/post.rb
@@ -14,6 +14,7 @@ module Main
       attribute :status, Status
       attribute :author_id, Types::Strict::Int
       attribute :published_at, Types::Strict::Time
+      attribute :color, Types::Strict::String
 
       class WithAuthor < Post
         attribute :author, "main.entities.user"

--- a/apps/main/lib/main/entities/post.rb
+++ b/apps/main/lib/main/entities/post.rb
@@ -14,7 +14,7 @@ module Main
       attribute :status, Status
       attribute :author_id, Types::Strict::Int
       attribute :published_at, Types::Strict::Time
-      attribute :color, Types::Strict::String
+      attribute :color, Types::PostHighlightColor
 
       class WithAuthor < Post
         attribute :author, "main.entities.user"

--- a/apps/main/lib/main/persistence/repositories/posts.rb
+++ b/apps/main/lib/main/persistence/repositories/posts.rb
@@ -19,7 +19,7 @@ module Main
             .published
             .per_page(per_page)
             .page(page)
-            .order(:published_at)
+            .order(Sequel.desc(:published_at))
             .combine(one: { author: [users, author_id: :id] })
             .as(Entities::Post::WithAuthor)
         end

--- a/apps/main/web/templates/posts/_snippet.html.slim
+++ b/apps/main/web/templates/posts/_snippet.html.slim
@@ -1,4 +1,4 @@
-article class="post-color-#{post.color}"
+article data-test-color=post.color
   a href="/posts/#{post.slug}" =post.title
   br
   = post.author.full_name

--- a/apps/main/web/templates/posts/_snippet.html.slim
+++ b/apps/main/web/templates/posts/_snippet.html.slim
@@ -1,7 +1,8 @@
-a href="/posts/#{post.slug}" =post.title
-br
-= post.author.full_name
-br
-= post.teaser
-br
-= post.published_date
+article class="post-color-#{post.color}"
+  a href="/posts/#{post.slug}" =post.title
+  br
+  = post.author.full_name
+  br
+  = post.teaser
+  br
+  = post.published_date

--- a/db/migrate/20160518053553_add_colour_to_posts.rb
+++ b/db/migrate/20160518053553_add_colour_to_posts.rb
@@ -1,0 +1,9 @@
+ROM::SQL.migration do
+  up do
+    add_column :posts, :colour, String, null: false, default: ""
+  end
+
+  down do
+    drop_column :posts, :colour
+  end
+end

--- a/db/migrate/20160519012636_rename_colour_to_color.rb
+++ b/db/migrate/20160519012636_rename_colour_to_color.rb
@@ -1,0 +1,5 @@
+ROM::SQL.migration do
+  change do
+    rename_column :posts, :colour, :color
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -118,7 +118,7 @@ CREATE TABLE posts (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL,
     teaser text DEFAULT ''::text NOT NULL,
-    colour text DEFAULT ''::text NOT NULL
+    color text DEFAULT ''::text NOT NULL
 );
 
 
@@ -206,7 +206,8 @@ CREATE TABLE users (
     access_token_expiration timestamp without time zone NOT NULL,
     active boolean DEFAULT true NOT NULL,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
-    updated_at timestamp without time zone DEFAULT now() NOT NULL
+    updated_at timestamp without time zone DEFAULT now() NOT NULL,
+    bio text DEFAULT ''::text
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -44,7 +44,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: categories; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: categories; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE categories (
@@ -74,7 +74,7 @@ ALTER SEQUENCE categories_id_seq OWNED BY categories.id;
 
 
 --
--- Name: categorisations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: categorisations; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE categorisations (
@@ -104,7 +104,7 @@ ALTER SEQUENCE categorisations_id_seq OWNED BY categorisations.id;
 
 
 --
--- Name: posts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: posts; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE posts (
@@ -142,7 +142,7 @@ ALTER SEQUENCE posts_id_seq OWNED BY posts.id;
 
 
 --
--- Name: que_jobs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: que_jobs; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE que_jobs (
@@ -184,7 +184,7 @@ ALTER SEQUENCE que_jobs_job_id_seq OWNED BY que_jobs.job_id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE schema_migrations (
@@ -193,7 +193,7 @@ CREATE TABLE schema_migrations (
 
 
 --
--- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE users (
@@ -206,8 +206,7 @@ CREATE TABLE users (
     access_token_expiration timestamp without time zone NOT NULL,
     active boolean DEFAULT true NOT NULL,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
-    updated_at timestamp without time zone DEFAULT now() NOT NULL,
-    bio text DEFAULT ''::text
+    updated_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
 
@@ -266,7 +265,7 @@ ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regcl
 
 
 --
--- Name: categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY categories
@@ -274,7 +273,7 @@ ALTER TABLE ONLY categories
 
 
 --
--- Name: categorisations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: categorisations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY categorisations
@@ -282,7 +281,7 @@ ALTER TABLE ONLY categorisations
 
 
 --
--- Name: posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY posts
@@ -290,7 +289,7 @@ ALTER TABLE ONLY posts
 
 
 --
--- Name: posts_slug_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: posts_slug_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY posts
@@ -298,7 +297,7 @@ ALTER TABLE ONLY posts
 
 
 --
--- Name: que_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: que_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY que_jobs
@@ -306,7 +305,7 @@ ALTER TABLE ONLY que_jobs
 
 
 --
--- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY schema_migrations
@@ -314,7 +313,7 @@ ALTER TABLE ONLY schema_migrations
 
 
 --
--- Name: users_email_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: users_email_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY users
@@ -322,7 +321,7 @@ ALTER TABLE ONLY users
 
 
 --
--- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY users

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -117,7 +117,8 @@ CREATE TABLE posts (
     published_at timestamp without time zone,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL,
-    teaser text DEFAULT ''::text NOT NULL
+    teaser text DEFAULT ''::text NOT NULL,
+    colour text DEFAULT ''::text NOT NULL
 );
 
 

--- a/lib/persistence/relations/posts.rb
+++ b/lib/persistence/relations/posts.rb
@@ -7,6 +7,7 @@ module Persistence
         attribute :teaser, Types::String
         attribute :body, Types::String
         attribute :slug, Types::String
+        attribute :colour, Types::String
         attribute :status, Types::String
         attribute :author_id, Types::ForeignKey(:users)
         attribute :published_at, Types::Time

--- a/lib/persistence/relations/posts.rb
+++ b/lib/persistence/relations/posts.rb
@@ -7,7 +7,7 @@ module Persistence
         attribute :teaser, Types::String
         attribute :body, Types::String
         attribute :slug, Types::String
-        attribute :colour, Types::String
+        attribute :color, Types::String
         attribute :status, Types::String
         attribute :author_id, Types::ForeignKey(:users)
         attribute :published_at, Types::Time

--- a/lib/types.rb
+++ b/lib/types.rb
@@ -3,5 +3,5 @@ require "dry-types"
 module Types
   include Dry::Types.module
 
-  Color = Types::Strict::String.enum("blue", "yellow", "red")
+  PostHighlightColor = Types::Strict::String.enum("blue", "yellow", "red")
 end

--- a/lib/types.rb
+++ b/lib/types.rb
@@ -3,5 +3,5 @@ require "dry-types"
 module Types
   include Dry::Types.module
 
-  PostHighlightColor = Types::Strict::String.enum("blue", "yellow", "red")
+  PostHighlightColor = Types::Strict::String.enum("red", "orange", "yellow","green", "blue", "indigo", "violet")
 end

--- a/lib/types.rb
+++ b/lib/types.rb
@@ -2,4 +2,6 @@ require "dry-types"
 
 module Types
   include Dry::Types.module
+
+  Colour = Types::Strict::String.default("blue").enum("blue", "yellow", "red")
 end

--- a/lib/types.rb
+++ b/lib/types.rb
@@ -3,5 +3,5 @@ require "dry-types"
 module Types
   include Dry::Types.module
 
-  Colour = Types::Strict::String.default("blue").enum("blue", "yellow", "red")
+  Color = Types::Strict::String.enum("blue", "yellow", "red")
 end

--- a/spec/admin/features/posts/create_spec.rb
+++ b/spec/admin/features/posts/create_spec.rb
@@ -23,8 +23,6 @@ RSpec.feature "Admin / Posts / Create", js: true do
     find(:xpath, "//button[contains(@class, 'selection-field')]", match: :first).trigger("click")
     find(:xpath, "//button[contains(@class, 'selection-field__optionButton')][div='#{jane.first_name} #{jane.last_name}']").trigger("click")
 
-    find("#colour").select("Blue")
-
     find("button", text: "Create post").trigger("click")
 
     expect(page).to have_content("Post has been created")
@@ -58,8 +56,6 @@ RSpec.feature "Admin / Posts / Create", js: true do
 
     find(:xpath, "//button[contains(@class, 'selection-field')]", match: :first).trigger("click")
     find(:xpath, "//button[contains(@class, 'selection-field__optionButton')][div='#{jane.first_name} #{jane.last_name}']").trigger("click")
-
-    find("#colour").select("Blue")
 
     find(:xpath, "//button[contains(@class, 'multi-selection-field')]").trigger("click")
     find(:xpath, "//button[contains(@class, 'multi-selection-field__optionButton')][div='My Tag']").trigger("click")

--- a/spec/admin/features/posts/create_spec.rb
+++ b/spec/admin/features/posts/create_spec.rb
@@ -68,4 +68,34 @@ RSpec.feature "Admin / Posts / Create", js: true do
 
     expect(page).to have_content("My Tag")
   end
+
+  scenario "A new post gets a color assigned" do
+    find("nav a", text: "Posts").trigger("click")
+
+    find("a", text: "Add a post").trigger("click")
+
+    find("#title").set("A sample title")
+    find("#teaser").set("A teaser for this sample article")
+    find("#body").set("Some sample content for this post")
+
+    find(:xpath, "//button[contains(@class, 'selection-field')]", match: :first).trigger("click")
+    find(:xpath, "//button[contains(@class, 'selection-field__optionButton')][div='#{jane.first_name} #{jane.last_name}']").trigger("click")
+
+    find("button", text: "Create post").trigger("click")
+
+    expect(page).to have_content("Post has been created")
+
+    expect(page).to have_content("A sample title")
+
+    click_link "A sample title"
+
+    select("Published", from: "Status")
+
+    find("input[name='post[published_at]']", visible: false).set(Time.now)
+    click_button "Save changes"
+
+    visit "/posts"
+
+    expect(page).to have_css("[data-test-color]:not([data-test-color=''])")
+  end
 end

--- a/spec/admin/features/posts/create_spec.rb
+++ b/spec/admin/features/posts/create_spec.rb
@@ -23,6 +23,8 @@ RSpec.feature "Admin / Posts / Create", js: true do
     find(:xpath, "//button[contains(@class, 'selection-field')]", match: :first).trigger("click")
     find(:xpath, "//button[contains(@class, 'selection-field__optionButton')][div='#{jane.first_name} #{jane.last_name}']").trigger("click")
 
+    find("#colour").select("Blue")
+
     find("button", text: "Create post").trigger("click")
 
     expect(page).to have_content("Post has been created")
@@ -56,6 +58,8 @@ RSpec.feature "Admin / Posts / Create", js: true do
 
     find(:xpath, "//button[contains(@class, 'selection-field')]", match: :first).trigger("click")
     find(:xpath, "//button[contains(@class, 'selection-field__optionButton')][div='#{jane.first_name} #{jane.last_name}']").trigger("click")
+
+    find("#colour").select("Blue")
 
     find(:xpath, "//button[contains(@class, 'multi-selection-field')]").trigger("click")
     find(:xpath, "//button[contains(@class, 'multi-selection-field__optionButton')][div='My Tag']").trigger("click")

--- a/spec/admin/shared/app/admin_posts.rb
+++ b/spec/admin/shared/app/admin_posts.rb
@@ -8,8 +8,7 @@ RSpec.shared_context "admin posts" do
       "teaser" => "A teaser for this sample post",
       "body" => "Some sample content for this post",
       "author_id" => Admin::Container["admin.persistence.repositories.users"].by_email("jane@doe.org").id,
-      "slug" => title.to_slug.normalize.to_s,
-      "colour" => "blue"
+      "slug" => title.to_slug.normalize.to_s
     }.merge(attrs)).value
   end
 

--- a/spec/admin/shared/app/admin_posts.rb
+++ b/spec/admin/shared/app/admin_posts.rb
@@ -8,7 +8,8 @@ RSpec.shared_context "admin posts" do
       "teaser" => "A teaser for this sample post",
       "body" => "Some sample content for this post",
       "author_id" => Admin::Container["admin.persistence.repositories.users"].by_email("jane@doe.org").id,
-      "slug" => title.to_slug.normalize.to_s
+      "slug" => title.to_slug.normalize.to_s,
+      "colour" => "blue"
     }.merge(attrs)).value
   end
 

--- a/spec/admin/unit/posts/post_color_picker_spec.rb
+++ b/spec/admin/unit/posts/post_color_picker_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe Admin::Persistence::PostColorPicker do
   let(:colors) { Types::Color }
   let(:recent_colors) { ->(){ ["red","green","yellow"] } }
 
-  context "user exists" do
-    it "returns the user if the password matches" do
-      expect(post_color_picker.()).to eq "blue"
-    end
+  it "returns a color that isn't in the list of recent colors" do
+    expect(post_color_picker.()).to eq "blue"
   end
 end

--- a/spec/admin/unit/posts/post_color_picker_spec.rb
+++ b/spec/admin/unit/posts/post_color_picker_spec.rb
@@ -1,0 +1,14 @@
+require "admin_app_helper"
+
+RSpec.describe Admin::Persistence::PostColorPicker do
+  subject(:post_color_picker) { Admin::Persistence::PostColorPicker.new(colors, recent_colors) }
+
+  let(:colors) { Types::Color }
+  let(:recent_colors) { ->(){ ["red","green","yellow"] } }
+
+  context "user exists" do
+    it "returns the user if the password matches" do
+      expect(post_color_picker.()).to eq "blue"
+    end
+  end
+end

--- a/spec/admin/unit/posts/post_color_picker_spec.rb
+++ b/spec/admin/unit/posts/post_color_picker_spec.rb
@@ -3,7 +3,7 @@ require "admin_app_helper"
 RSpec.describe Admin::Persistence::PostColorPicker do
   subject(:post_color_picker) { Admin::Persistence::PostColorPicker.new(colors, recent_colors) }
 
-  let(:colors) { Types::PostHighlightColor }
+  let(:colors) { {1 => "red", 2 =>  "green",  3 => "yellow", 4 => "blue"} }
   let(:recent_colors) { ->(){ ["red","green","yellow"] } }
 
   it "returns a color that isn't in the list of recent colors" do

--- a/spec/admin/unit/posts/post_color_picker_spec.rb
+++ b/spec/admin/unit/posts/post_color_picker_spec.rb
@@ -3,7 +3,7 @@ require "admin_app_helper"
 RSpec.describe Admin::Persistence::PostColorPicker do
   subject(:post_color_picker) { Admin::Persistence::PostColorPicker.new(colors, recent_colors) }
 
-  let(:colors) { Types::Color }
+  let(:colors) { Types::PostHighlightColor }
   let(:recent_colors) { ->(){ ["red","green","yellow"] } }
 
   it "returns a color that isn't in the list of recent colors" do

--- a/spec/main/features/posts/index_spec.rb
+++ b/spec/main/features/posts/index_spec.rb
@@ -22,11 +22,11 @@ RSpec.feature "Main / Posts / Index", js: false do
 
     expect(page).to have_content("Older")
     expect(page).to have_content("Newer")
-    expect(page).to_not have_content("foo 21")
+    expect(page).to_not have_css("a[href='/posts/foo-1']")
 
     click_link("Older", :match => :first)
 
-    expect(page).to have_content("foo 21")
+    expect(page).to have_css("a[href='/posts/foo-1']")
 
   end
 end

--- a/spec/main/shared/app/main_posts.rb
+++ b/spec/main/shared/app/main_posts.rb
@@ -21,7 +21,8 @@ RSpec.shared_context 'main posts' do
       slug: title.to_slug.normalize.to_s,
       author_id: user[:id],
       status: status,
-      published_at: Time.now
+      published_at: Time.now,
+      colour: "blue"
     })
   end
 end

--- a/spec/main/shared/app/main_posts.rb
+++ b/spec/main/shared/app/main_posts.rb
@@ -22,7 +22,7 @@ RSpec.shared_context 'main posts' do
       author_id: user[:id],
       status: status,
       published_at: Time.now,
-      colour: "blue"
+      color: "blue"
     })
   end
 end


### PR DESCRIPTION
This PR adds color classes to posts and cleans up the post edit/creation forms.

![screen shot 2016-05-19 at 9 26 19 am](https://cloud.githubusercontent.com/assets/479627/15382565/b9d82f7e-1dce-11e6-8741-d5f559292c3a.png)
![screen shot 2016-05-19 at 9 30 57 am](https://cloud.githubusercontent.com/assets/479627/15382562/b9be3592-1dce-11e6-94bd-95ad88aa0590.png)

* A post can not have the same color as one of the 5 (can change) posts before it.
* Colors are picked from a pool of predetermined colors defined in `Types::PostHighlightColors`.
