### PR TITLE
Add about page and people listing

### DIFF
--- a/apps/admin/config/locales/admin.yml
+++ b/apps/admin/config/locales/admin.yml
@@ -24,6 +24,7 @@ en:
       page_update: "Page has been updated"
     people:
       person_created: "Person has been created"
+      person_updated: "Person has been updated"
     emails:
       users:
         account_activation:

--- a/apps/admin/config/locales/admin.yml
+++ b/apps/admin/config/locales/admin.yml
@@ -22,6 +22,8 @@ en:
       project_updated: "Project has been updated"
     pages:
       page_update: "Page has been updated"
+    people:
+      person_created: "Person has been created"
     emails:
       users:
         account_activation:

--- a/apps/admin/config/locales/admin.yml
+++ b/apps/admin/config/locales/admin.yml
@@ -20,6 +20,8 @@ en:
     projects:
       project_created: "Project has been created"
       project_updated: "Project has been updated"
+    pages:
+      page_update: "Page has been updated"
     emails:
       users:
         account_activation:

--- a/apps/admin/core/container/persistence.rb
+++ b/apps/admin/core/container/persistence.rb
@@ -8,6 +8,13 @@ Admin::Container.namespace "admin.persistence" do |container|
     )
   end
 
+  container.register "person_email_uniqueness_check" do
+    Admin::Persistence::UniquenessCheck.new(
+      container["core.persistence.rom"].relation(:people),
+      :email
+    )
+  end
+
   container.register "post_slug_uniqueness_check" do
     Admin::Persistence::UniquenessCheck.new(
       container["core.persistence.rom"].relation(:posts),

--- a/apps/admin/lib/admin/entities/person.rb
+++ b/apps/admin/lib/admin/entities/person.rb
@@ -4,8 +4,7 @@ module Admin
   module Entities
     class Person < Dry::Types::Value
       attribute :id, Types::Strict::Int
-      attribute :first_name, Types::Strict::String
-      attribute :last_name, Types::Strict::String
+      attribute :name, Types::Strict::String
       attribute :email, Types::Strict::String
       attribute :bio, Types::Strict::String
       attribute :short_bio, Types::Strict::String
@@ -13,10 +12,6 @@ module Admin
       attribute :job_title, Types::Maybe::Strict::String
       attribute :twitter, Types::Maybe::Strict::String
       attribute :website, Types::Maybe::Strict::String
-
-      def full_name
-        "#{first_name} #{last_name}"
-      end
     end
   end
 end

--- a/apps/admin/lib/admin/entities/person.rb
+++ b/apps/admin/lib/admin/entities/person.rb
@@ -1,0 +1,19 @@
+require "types"
+
+module Admin
+  module Entities
+    class Person < Dry::Types::Value
+      attribute :id, Types::Strict::Int
+      attribute :first_name, Types::Strict::String
+      attribute :last_name, Types::Strict::String
+      attribute :email, Types::Strict::String
+      attribute :active, Types::Strict::Bool
+
+      alias_method :active?, :active
+
+      def full_name
+        "#{first_name} #{last_name}"
+      end
+    end
+  end
+end

--- a/apps/admin/lib/admin/entities/person.rb
+++ b/apps/admin/lib/admin/entities/person.rb
@@ -8,6 +8,7 @@ module Admin
       attribute :last_name, Types::Strict::String
       attribute :email, Types::Strict::String
       attribute :bio, Types::Strict::String
+      attribute :short_bio, Types::Strict::String
       attribute :avatar, Types::Maybe::Strict::String
       attribute :job_title, Types::Maybe::Strict::String
       attribute :twitter, Types::Maybe::Strict::String

--- a/apps/admin/lib/admin/entities/person.rb
+++ b/apps/admin/lib/admin/entities/person.rb
@@ -7,9 +7,11 @@ module Admin
       attribute :first_name, Types::Strict::String
       attribute :last_name, Types::Strict::String
       attribute :email, Types::Strict::String
-      attribute :active, Types::Strict::Bool
-
-      alias_method :active?, :active
+      attribute :bio, Types::Strict::String
+      attribute :avatar, Types::Maybe::Strict::String
+      attribute :job_title, Types::Maybe::Strict::String
+      attribute :twitter, Types::Maybe::Strict::String
+      attribute :website, Types::Maybe::Strict::String
 
       def full_name
         "#{first_name} #{last_name}"

--- a/apps/admin/lib/admin/entities/post.rb
+++ b/apps/admin/lib/admin/entities/post.rb
@@ -12,7 +12,7 @@ module Admin
       attribute :body, Types::Strict::String
       attribute :slug, Types::Strict::String
       attribute :status, Status
-      attribute :author_id, Types::Strict::Int
+      attribute :person_id, Types::Strict::Int
       attribute :published_at, Types::Time
 
       def deleted?

--- a/apps/admin/lib/admin/pages/about/forms/edit_form.rb
+++ b/apps/admin/lib/admin/pages/about/forms/edit_form.rb
@@ -1,0 +1,33 @@
+require "berg/form"
+
+module Admin
+  module Pages
+    module About
+      module Forms
+        class EditForm < Berg::Form
+          include Admin::Import[
+            "admin.persistence.repositories.people"
+          ]
+
+          prefix :page
+
+          define do
+            multi_selection_field :about_page_people,
+              label: "People",
+              selector_label: "Choose people",
+              options: dep(:people_list)
+          end
+
+          def people_list
+            people.all_people.to_a.map { |person|
+              {
+                id: person.id,
+                label: person.full_name
+              }
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/lib/admin/pages/about/operations/update.rb
+++ b/apps/admin/lib/admin/pages/about/operations/update.rb
@@ -1,0 +1,30 @@
+require "admin/import"
+require "kleisli"
+require "types"
+
+module Admin
+  module Pages
+    module About
+      module Operations
+        class Update
+          include Admin::Import(
+            "core.persistence.commands.update_about_page_people"
+          )
+
+          include Dry::ResultMatcher.for(:call)
+
+          def call(attributes)
+            validation = Validation::Form.(attributes)
+
+            if validation.success?
+              about_page_people = update_about_page_people.(validation.output)
+              Right(about_page_people)
+            else
+              Left(validation)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/lib/admin/pages/about/validation/form.rb
+++ b/apps/admin/lib/admin/pages/about/validation/form.rb
@@ -1,0 +1,18 @@
+require "admin/container"
+require "berg/validation/form"
+
+module Admin
+  module Pages
+    module About
+      module Validation
+        Form = Berg::Validation.Form do
+          configure do
+            config.messages = :i18n
+          end
+
+          optional(:about_page_people).each(:int?)
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/lib/admin/people/forms/create_form.rb
+++ b/apps/admin/lib/admin/people/forms/create_form.rb
@@ -11,7 +11,7 @@ module Admin
             label: "Email",
             validation: {
               filled: true,
-              format: "/.+@.+\..+/i"
+              format: EMAIL_VALIDATION_REGEX
             }
           text_field :first_name, label: "First name"
           text_field :last_name, label: "Last name"

--- a/apps/admin/lib/admin/people/forms/create_form.rb
+++ b/apps/admin/lib/admin/people/forms/create_form.rb
@@ -8,8 +8,7 @@ module Admin
 
         define do
           group do
-            text_field :first_name, label: "First name"
-            text_field :last_name, label: "Last name"
+            text_field :name, label: "Name"
           end
 
           group do

--- a/apps/admin/lib/admin/people/forms/create_form.rb
+++ b/apps/admin/lib/admin/people/forms/create_form.rb
@@ -7,16 +7,24 @@ module Admin
         prefix :person
 
         define do
-          text_field :email,
-            label: "Email",
-            validation: {
-              filled: true,
-              format: EMAIL_VALIDATION_REGEX
-            }
-          text_field :first_name, label: "First name"
-          text_field :last_name, label: "Last name"
+          group do
+            text_field :first_name, label: "First name"
+            text_field :last_name, label: "Last name"
+          end
+          group do
+            text_field :email,
+              label: "Email",
+              validation: {
+                filled: true,
+                format: EMAIL_VALIDATION_REGEX
+              }
+            text_field :job_title, label: "Job Title"
+          end
+          group do
+            text_field :twitter, label: "Twitter Username"
+            text_field :website, label: "Website URL"
+          end
           text_area :bio, label: "Bio"
-          check_box :active, label: "Status", question_text: "Mark as active?"
         end
       end
     end

--- a/apps/admin/lib/admin/people/forms/create_form.rb
+++ b/apps/admin/lib/admin/people/forms/create_form.rb
@@ -11,6 +11,7 @@ module Admin
             text_field :first_name, label: "First name"
             text_field :last_name, label: "Last name"
           end
+
           group do
             text_field :email,
               label: "Email",
@@ -20,12 +21,19 @@ module Admin
               }
             text_field :job_title, label: "Job Title"
           end
-          group do
-            text_field :twitter, label: "Twitter Username"
-            text_field :website, label: "Website URL"
-          end
+
           text_area :bio, label: "Bio"
           text_area :short_bio, label: "Short Bio"
+
+          upload_field :avatar,
+            label: "Avatar",
+            hint: "An image of this person",
+            presign_url: "#{Berg::Container["config"].canonical_domain}/admin/uploads/presign"
+
+          group label: :social do
+            text_field :website, label: "Website", placeholder: "http://foo.com", hint: "(optional)"
+            text_field :twitter, label: "Twitter", placeholder: "http://twitter.com/username", hint: "(optional)"
+          end
         end
       end
     end

--- a/apps/admin/lib/admin/people/forms/create_form.rb
+++ b/apps/admin/lib/admin/people/forms/create_form.rb
@@ -25,6 +25,7 @@ module Admin
             text_field :website, label: "Website URL"
           end
           text_area :bio, label: "Bio"
+          text_area :short_bio, label: "Short Bio"
         end
       end
     end

--- a/apps/admin/lib/admin/people/forms/create_form.rb
+++ b/apps/admin/lib/admin/people/forms/create_form.rb
@@ -1,0 +1,24 @@
+require "berg/form"
+
+module Admin
+  module People
+    module Forms
+      class CreateForm < Berg::Form
+        prefix :person
+
+        define do
+          text_field :email,
+            label: "Email",
+            validation: {
+              filled: true,
+              format: "/.+@.+\..+/i"
+            }
+          text_field :first_name, label: "First name"
+          text_field :last_name, label: "Last name"
+          text_area :bio, label: "Bio"
+          check_box :active, label: "Status", question_text: "Mark as active?"
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/lib/admin/people/forms/edit_form.rb
+++ b/apps/admin/lib/admin/people/forms/edit_form.rb
@@ -11,7 +11,7 @@ module Admin
             label: "Email",
             validation: {
               filled: true,
-              format: "/.+@.+\..+/i"
+              format: EMAIL_VALIDATION_REGEX
             }
           text_field :first_name, label: "First name"
           text_field :last_name, label: "Last name"

--- a/apps/admin/lib/admin/people/forms/edit_form.rb
+++ b/apps/admin/lib/admin/people/forms/edit_form.rb
@@ -8,8 +8,7 @@ module Admin
 
         define do
           group do
-            text_field :first_name, label: "First name"
-            text_field :last_name, label: "Last name"
+            text_field :name, label: "Name"
           end
 
           group do

--- a/apps/admin/lib/admin/people/forms/edit_form.rb
+++ b/apps/admin/lib/admin/people/forms/edit_form.rb
@@ -7,16 +7,24 @@ module Admin
         prefix :person
 
         define do
-          text_field :email,
-            label: "Email",
-            validation: {
-              filled: true,
-              format: EMAIL_VALIDATION_REGEX
-            }
-          text_field :first_name, label: "First name"
-          text_field :last_name, label: "Last name"
+          group do
+            text_field :first_name, label: "First name"
+            text_field :last_name, label: "Last name"
+          end
+          group do
+            text_field :email,
+              label: "Email",
+              validation: {
+                filled: true,
+                format: EMAIL_VALIDATION_REGEX
+              }
+            text_field :job_title, label: "Job Title"
+          end
+          group do
+            text_field :twitter, label: "Twitter Username"
+            text_field :website, label: "Website URL"
+          end
           text_area :bio, label: "Bio"
-          check_box :active, label: "Status", question_text: "Mark as active?"
         end
       end
     end

--- a/apps/admin/lib/admin/people/forms/edit_form.rb
+++ b/apps/admin/lib/admin/people/forms/edit_form.rb
@@ -11,6 +11,7 @@ module Admin
             text_field :first_name, label: "First name"
             text_field :last_name, label: "Last name"
           end
+
           group do
             text_field :email,
               label: "Email",
@@ -20,12 +21,19 @@ module Admin
               }
             text_field :job_title, label: "Job Title"
           end
-          group do
-            text_field :twitter, label: "Twitter Username"
-            text_field :website, label: "Website URL"
-          end
+
           text_area :bio, label: "Bio"
           text_area :short_bio, label: "Short Bio"
+
+          upload_field :avatar,
+            label: "Avatar",
+            hint: "An image of this person",
+            presign_url: "#{Berg::Container["config"].canonical_domain}/admin/uploads/presign"
+
+          group label: :social do
+            text_field :website, label: "Website", placeholder: "http://foo.com", hint: "(optional)"
+            text_field :twitter, label: "Twitter", placeholder: "http://twitter.com/username", hint: "(optional)"
+          end
         end
       end
     end

--- a/apps/admin/lib/admin/people/forms/edit_form.rb
+++ b/apps/admin/lib/admin/people/forms/edit_form.rb
@@ -25,6 +25,7 @@ module Admin
             text_field :website, label: "Website URL"
           end
           text_area :bio, label: "Bio"
+          text_area :short_bio, label: "Short Bio"
         end
       end
     end

--- a/apps/admin/lib/admin/people/forms/edit_form.rb
+++ b/apps/admin/lib/admin/people/forms/edit_form.rb
@@ -1,0 +1,24 @@
+require "berg/form"
+
+module Admin
+  module People
+    module Forms
+      class EditForm < Berg::Form
+        prefix :person
+
+        define do
+          text_field :email,
+            label: "Email",
+            validation: {
+              filled: true,
+              format: "/.+@.+\..+/i"
+            }
+          text_field :first_name, label: "First name"
+          text_field :last_name, label: "Last name"
+          text_area :bio, label: "Bio"
+          check_box :active, label: "Status", question_text: "Mark as active?"
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/lib/admin/people/operations/create.rb
+++ b/apps/admin/lib/admin/people/operations/create.rb
@@ -1,0 +1,30 @@
+require "admin/import"
+require "admin/entities/person"
+require "admin/people/validation/form"
+require "kleisli"
+require "types"
+
+module Admin
+  module People
+    module Operations
+      class Create
+        include Admin::Import(
+          "admin.persistence.repositories.people",
+        )
+
+        include Dry::ResultMatcher.for(:call)
+
+        def call(attributes)
+          validation = Validation::Form.(attributes)
+
+          if validation.success?
+            person = Entities::Person.new(people.create(validation.output))
+            Right(person)
+          else
+            Left(validation)
+          end
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/lib/admin/people/operations/update.rb
+++ b/apps/admin/lib/admin/people/operations/update.rb
@@ -1,0 +1,38 @@
+require "admin/import"
+require "admin/entities/person"
+require "admin/people/validation/form"
+require "kleisli"
+
+module Admin
+  module People
+    module Operations
+      class Update
+        include Admin::Import(
+          "admin.persistence.repositories.people",
+          "core.authentication.encrypt_password"
+        )
+
+        include Dry::ResultMatcher.for(:call)
+
+        def call(id, attributes)
+          validation = Validation::Form.(prepare_attributes(attributes))
+
+          if validation.success?
+            people.update(id, validation.output)
+            Right(people[id])
+          else
+            Left(validation)
+          end
+        end
+
+        private
+
+        def prepare_attributes(attributes)
+          attributes.merge(
+            previous_email: attributes["email"]
+          )
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/lib/admin/people/operations/update.rb
+++ b/apps/admin/lib/admin/people/operations/update.rb
@@ -16,7 +16,7 @@ module Admin
 
         def call(id, attributes)
           validation = Validation::Form.(prepare_attributes(attributes))
-
+          # raise validation.output.inspect
           if validation.success?
             people.update(id, validation.output)
             Right(people[id])

--- a/apps/admin/lib/admin/people/validation/form.rb
+++ b/apps/admin/lib/admin/people/validation/form.rb
@@ -23,8 +23,7 @@ module Admin
         optional(:bio).filled
         optional(:short_bio).filled
         optional(:previous_email).maybe
-        optional(:first_name).filled
-        optional(:last_name).filled
+        optional(:name).filled
 
         optional(:avatar).maybe(:str?)
         optional(:twitter).maybe(:str?)

--- a/apps/admin/lib/admin/people/validation/form.rb
+++ b/apps/admin/lib/admin/people/validation/form.rb
@@ -24,6 +24,12 @@ module Admin
         optional(:previous_email).maybe
         optional(:first_name).filled
         optional(:last_name).filled
+
+        optional(:avatar).maybe(:str?)
+        optional(:twitter).maybe(:str?)
+        optional(:job_title).maybe(:str?)
+        optional(:website).maybe(:str?)
+
         optional(:active).filled(:bool?)
 
         rule(email: [:email, :previous_email]) do |email, previous_email|

--- a/apps/admin/lib/admin/people/validation/form.rb
+++ b/apps/admin/lib/admin/people/validation/form.rb
@@ -21,6 +21,7 @@ module Admin
 
         optional(:email).filled
         optional(:bio).filled
+        optional(:short_bio).filled
         optional(:previous_email).maybe
         optional(:first_name).filled
         optional(:last_name).filled

--- a/apps/admin/lib/admin/people/validation/form.rb
+++ b/apps/admin/lib/admin/people/validation/form.rb
@@ -1,0 +1,35 @@
+require "admin/container"
+require "berg/validation/form"
+
+module Admin
+  module People
+    module Validation
+      Form = Berg::Validation.Form do
+        configure do
+          config.messages = :i18n
+
+          option :person_email_uniqueness_check, Admin::Container["admin.persistence.person_email_uniqueness_check"]
+
+          def email_unique?(value)
+            person_email_uniqueness_check.(value)
+          end
+
+          def not_eql?(input, value)
+            !input.eql?(value)
+          end
+        end
+
+        optional(:email).filled
+        optional(:bio).filled
+        optional(:previous_email).maybe
+        optional(:first_name).filled
+        optional(:last_name).filled
+        optional(:active).filled(:bool?)
+
+        rule(email: [:email, :previous_email]) do |email, previous_email|
+          email.not_eql?(previous_email).then(email.email_unique?)
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/lib/admin/people/validation/form.rb
+++ b/apps/admin/lib/admin/people/validation/form.rb
@@ -31,8 +31,6 @@ module Admin
         optional(:job_title).maybe(:str?)
         optional(:website).maybe(:str?)
 
-        optional(:active).filled(:bool?)
-
         rule(email: [:email, :previous_email]) do |email, previous_email|
           email.not_eql?(previous_email).then(email.email_unique?)
         end

--- a/apps/admin/lib/admin/persistence/repositories/about_page_people.rb
+++ b/apps/admin/lib/admin/persistence/repositories/about_page_people.rb
@@ -1,0 +1,17 @@
+require "berg/repository"
+
+module Admin
+  module Persistence
+    module Repositories
+      class AboutPagePeople < Berg::Repository[:about_page_people]
+        relations :about_page_people
+
+        def all_people
+          about_page_people
+            .order(:position)
+            .to_a
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/lib/admin/persistence/repositories/about_page_people.rb
+++ b/apps/admin/lib/admin/persistence/repositories/about_page_people.rb
@@ -6,7 +6,7 @@ module Admin
       class AboutPagePeople < Berg::Repository[:about_page_people]
         relations :about_page_people
 
-        def all_people
+        def listing_by_position
           about_page_people
             .order(:position)
             .to_a

--- a/apps/admin/lib/admin/persistence/repositories/people.rb
+++ b/apps/admin/lib/admin/persistence/repositories/people.rb
@@ -20,13 +20,13 @@ module Admin
           people
             .per_page(per_page)
             .page(page)
-            .order(:first_name)
+            .order(:name)
             .as(Entities::Person)
         end
 
         def all_people
           people
-            .order(:first_name)
+            .order(:name)
             .as(Entities::Person)
             .to_a
         end

--- a/apps/admin/lib/admin/persistence/repositories/people.rb
+++ b/apps/admin/lib/admin/persistence/repositories/people.rb
@@ -12,6 +12,10 @@ module Admin
           people.by_id(id).as(Entities::Person).one
         end
 
+        def by_email(email)
+          people.by_email(email).as(Entities::Person).one
+        end
+
         def listing(per_page: 20, page: 1)
           people
             .per_page(per_page)
@@ -24,6 +28,7 @@ module Admin
           people
             .order(:first_name)
             .as(Entities::Person)
+            .to_a
         end
       end
     end

--- a/apps/admin/lib/admin/persistence/repositories/people.rb
+++ b/apps/admin/lib/admin/persistence/repositories/people.rb
@@ -1,0 +1,31 @@
+require "berg/repository"
+require "admin/entities/person"
+
+module Admin
+  module Persistence
+    module Repositories
+      class People < Berg::Repository[:people]
+        relations :people
+        commands :create, update: [:by_id]
+
+        def [](id)
+          people.by_id(id).as(Entities::Person).one
+        end
+
+        def listing(per_page: 20, page: 1)
+          people
+            .per_page(per_page)
+            .page(page)
+            .order(:first_name)
+            .as(Entities::Person)
+        end
+
+        def all_people
+          people
+            .order(:first_name)
+            .as(Entities::Person)
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/lib/admin/posts/forms/create_form.rb
+++ b/apps/admin/lib/admin/posts/forms/create_form.rb
@@ -23,7 +23,7 @@ module Admin
         end
 
         def author_list
-          people.all_people.map { |person| { id: person.id, label: person.full_name } }
+          people.all_people.map { |person| { id: person.id, label: person.name } }
         end
 
         def categories_list

--- a/apps/admin/lib/admin/posts/forms/create_form.rb
+++ b/apps/admin/lib/admin/posts/forms/create_form.rb
@@ -5,7 +5,7 @@ module Admin
     module Forms
       class CreateForm < Berg::Form
         include Admin::Import[
-          "admin.persistence.repositories.users",
+          "admin.persistence.repositories.people",
           "admin.persistence.repositories.categories"
         ]
 
@@ -15,7 +15,7 @@ module Admin
           text_field :title, label: "Title"
           text_field :teaser, label: "Teaser"
           text_area :body, label: "Body"
-          selection_field :author_id, label: "Author", options: dep(:author_list)
+          selection_field :person_id, label: "Author", options: dep(:author_list)
           multi_selection_field :post_categories,
             label: "Categories",
             selector_label: "Choose categories",
@@ -23,7 +23,7 @@ module Admin
         end
 
         def author_list
-          users.listing.map { |user| { id: user.id, label: user.full_name } }
+          people.all_people.map { |person| { id: person.id, label: person.full_name } }
         end
 
         def categories_list

--- a/apps/admin/lib/admin/posts/forms/edit_form.rb
+++ b/apps/admin/lib/admin/posts/forms/edit_form.rb
@@ -27,7 +27,7 @@ module Admin
         end
 
         def author_list
-          people.all_people.map { |person| { id: person.id, label: person.full_name } }
+          people.all_people.map { |person| { id: person.id, label: person.name } }
         end
 
         def status_list

--- a/apps/admin/lib/admin/posts/forms/edit_form.rb
+++ b/apps/admin/lib/admin/posts/forms/edit_form.rb
@@ -5,7 +5,7 @@ module Admin
     module Forms
       class EditForm < Berg::Form
         include Admin::Import[
-          "admin.persistence.repositories.users",
+          "admin.persistence.repositories.people",
           "admin.persistence.repositories.categories"
         ]
 
@@ -16,7 +16,7 @@ module Admin
           text_field :teaser, label: "Teaser"
           text_area :body, label: "Body"
           text_field :slug, label: "Slug"
-          selection_field :author_id, label: "Author", options: dep(:author_list)
+          selection_field :person_id, label: "Author", options: dep(:author_list)
           select_box :status, label: "Status", options: dep(:status_list)
           date_time_field :published_at, label: "Published at"
           multi_selection_field :post_categories,
@@ -27,7 +27,7 @@ module Admin
         end
 
         def author_list
-          users.listing.map { |user| { id: user.id, label: user.full_name } }
+          people.all_people.map { |person| { id: person.id, label: person.full_name } }
         end
 
         def status_list

--- a/apps/admin/lib/admin/posts/validation/form.rb
+++ b/apps/admin/lib/admin/posts/validation/form.rb
@@ -23,12 +23,12 @@ module Admin
         required(:title).filled
         required(:teaser).filled
         required(:body).filled
-        required(:author_id).filled(:int?)
+        required(:person_id).filled(:int?)
 
         # Required in only the edit form
         optional(:slug).filled
         optional(:previous_slug).maybe
-        optional(:author_id).filled(:int?)
+        optional(:person_id).filled(:int?)
         optional(:post_categories).each(:int?)
         optional(:status).filled(included_in?: Entities::Post::Status.values)
         optional(:published_at).maybe(:time?)

--- a/apps/admin/lib/admin/uploads/operations/presign.rb
+++ b/apps/admin/lib/admin/uploads/operations/presign.rb
@@ -1,0 +1,37 @@
+require "admin/import"
+require "securerandom"
+require "openssl"
+
+module Admin
+  module Uploads
+    module Operations
+      class Presign
+        include Dry::ResultMatcher.for(:call)
+
+        def call()
+          uuid = SecureRandom.uuid
+          expiration = (Time.now + 60*60*3).to_i
+
+          payload = {
+            url: "#{attache_host}/upload",
+            uuid: uuid,
+            expiration: expiration,
+            hmac: OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"), attache_secret_key, "#{uuid}#{expiration}"),
+          }
+
+          Right(payload)
+        end
+
+        private
+
+        def attache_host
+          Berg::Container["config"].attache_uploads_base_url
+        end
+
+        def attache_secret_key
+          Berg::Container["config"].attache_secret_key
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/lib/admin/users/forms/create_form.rb
+++ b/apps/admin/lib/admin/users/forms/create_form.rb
@@ -11,7 +11,7 @@ module Admin
             label: "Email",
             validation: {
               filled: true,
-              format: "/.+@.+\..+/i"
+              format: EMAIL_VALIDATION_REGEX
             }
           text_field :first_name, label: "First name"
           text_field :last_name, label: "Last name"

--- a/apps/admin/lib/admin/users/forms/edit_form.rb
+++ b/apps/admin/lib/admin/users/forms/edit_form.rb
@@ -11,7 +11,7 @@ module Admin
             label: "Email",
             validation: {
               filled: true,
-              format: "/.+@.+\..+/i"
+              format: EMAIL_VALIDATION_REGEX
             }
           text_field :first_name, label: "First name"
           text_field :last_name, label: "Last name"

--- a/apps/admin/lib/admin/users/operations/update.rb
+++ b/apps/admin/lib/admin/users/operations/update.rb
@@ -16,7 +16,6 @@ module Admin
 
         def call(id, attributes)
           validation = Validation::Form.(prepare_attributes(attributes))
-
           if validation.success?
             users.update(id, validation.output)
             Right(users[id])

--- a/apps/admin/lib/admin/views/pages/about/edit.rb
+++ b/apps/admin/lib/admin/views/pages/about/edit.rb
@@ -1,0 +1,49 @@
+require "admin/import"
+require "admin/view"
+require "admin/pages/about/forms/edit_form"
+
+module Admin
+  module Views
+    module Pages
+      module About
+        class Edit < Admin::View
+          include Admin::Import(
+            "admin.persistence.repositories.about_page_people",
+            "admin.persistence.repositories.people",
+            "admin.pages.about.forms.edit_form",
+          )
+
+          configure do |config|
+            config.template = "pages/about/edit"
+          end
+
+          def locals(options = {})
+            selected_about_page_people = about_page_people.all_people
+
+            page_validation = options[:page_validation]
+
+            super.merge(
+              page_form: page_form(selected_about_page_people, page_validation)
+            )
+          end
+
+          private
+
+          def page_form(people_list, validation)
+            if validation
+              edit_form.build(validation, validation.messages)
+            else
+              edit_form.build(form_input(people_list))
+            end
+          end
+
+          def form_input(people_list)
+            {
+              about_page_people: people_list.map(&:person_id)
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/lib/admin/views/pages/about/edit.rb
+++ b/apps/admin/lib/admin/views/pages/about/edit.rb
@@ -18,7 +18,7 @@ module Admin
           end
 
           def locals(options = {})
-            selected_about_page_people = about_page_people.all_people
+            selected_about_page_people = about_page_people.listing_by_position
 
             page_validation = options[:page_validation]
 

--- a/apps/admin/lib/admin/views/people/edit.rb
+++ b/apps/admin/lib/admin/views/people/edit.rb
@@ -21,7 +21,7 @@ module Admin
 
           super.merge(
             person: person,
-            person_form: person_form(person, person_validation)
+            person_form: person_form(prepare_values(person), person_validation)
           )
         end
 
@@ -33,6 +33,14 @@ module Admin
           else
             edit_form.build(person)
           end
+        end
+
+        def prepare_values(person)
+          person.to_h.merge(
+            twitter: person.twitter.value,
+            website: person.website.value,
+            job_title: person.job_title.value
+          )
         end
       end
     end

--- a/apps/admin/lib/admin/views/people/edit.rb
+++ b/apps/admin/lib/admin/views/people/edit.rb
@@ -1,0 +1,40 @@
+require "admin/import"
+require "admin/view"
+
+module Admin
+  module Views
+    module People
+      class Edit < Admin::View
+        include Admin::Import(
+          "admin.persistence.repositories.people",
+          "admin.people.forms.edit_form",
+        )
+
+        configure do |config|
+          config.template = "people/edit"
+        end
+
+        def locals(options = {})
+          person = people[options[:id]]
+
+          person_validation = options[:person_validation]
+
+          super.merge(
+            person: person,
+            person_form: person_form(person, person_validation)
+          )
+        end
+
+        private
+
+        def person_form(person, validation)
+          if validation
+            edit_form.build(validation, validation.messages)
+          else
+            edit_form.build(person)
+          end
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/lib/admin/views/people/edit.rb
+++ b/apps/admin/lib/admin/views/people/edit.rb
@@ -21,7 +21,8 @@ module Admin
 
           super.merge(
             person: person,
-            person_form: person_form(prepare_values(person), person_validation)
+            person_form: person_form(prepare_values(person), person_validation),
+            csrf_token: options[:scope].csrf_token
           )
         end
 
@@ -37,6 +38,7 @@ module Admin
 
         def prepare_values(person)
           person.to_h.merge(
+            avatar: person.avatar.value,
             twitter: person.twitter.value,
             website: person.website.value,
             job_title: person.job_title.value

--- a/apps/admin/lib/admin/views/people/index.rb
+++ b/apps/admin/lib/admin/views/people/index.rb
@@ -1,0 +1,30 @@
+require "admin/import"
+require "admin/paginator"
+require "admin/view"
+
+module Admin
+  module Views
+    module People
+      class Index < Admin::View
+        include Admin::Import("admin.persistence.repositories.people")
+
+        configure do |config|
+          config.template = "people/index"
+        end
+
+        def locals(options = {})
+          page      = options[:page] || 1
+          per_page  = options[:per_page] || 20
+
+          all_people = people.listing(page: page, per_page: per_page)
+          admin_people = all_people.to_a.map { |a| Decorators::Post.new(a) }
+
+          super.merge(
+            people: admin_people,
+            paginator: Paginator.new(all_people.pager, url_template: "/admin/people?page=%")
+          )
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/lib/admin/views/people/new.rb
+++ b/apps/admin/lib/admin/views/people/new.rb
@@ -12,7 +12,10 @@ module Admin
         end
 
         def locals(options = {})
-          super.merge(person_form: form_data(options[:validation]))
+          super.merge(
+            person_form: form_data(options[:validation]),
+            csrf_token: options[:scope].csrf_token
+          )
         end
 
         def form_data(validation)

--- a/apps/admin/lib/admin/views/people/new.rb
+++ b/apps/admin/lib/admin/views/people/new.rb
@@ -1,0 +1,28 @@
+require "admin/import"
+require "admin/view"
+
+module Admin
+  module Views
+    module People
+      class New < Admin::View
+        include Admin::Import("admin.people.forms.create_form")
+
+        configure do |config|
+          config.template = "people/new"
+        end
+
+        def locals(options = {})
+          super.merge(person_form: form_data(options[:validation]))
+        end
+
+        def form_data(validation)
+          if validation
+            create_form.build(validation, validation.messages)
+          else
+            create_form.build
+          end
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/web/routes/pages.rb
+++ b/apps/admin/web/routes/pages.rb
@@ -1,0 +1,28 @@
+class Admin::Application < Dry::Web::Application
+  route "pages" do |r|
+    r.authorize do
+      r.on "about" do
+        r.is do
+          r.get do
+            r.view "pages.about.edit"
+          end
+
+          r.post do
+            r.resolve "admin.pages.about.operations.update" do |update_about_page|
+              update_about_page.(r[:page]) do |m|
+                m.success do
+                  flash[:notice] = t["admin.pages.page_update"]
+                  r.redirect "/admin"
+                end
+
+                m.failure do |validation|
+                  r.view "pages.about.edit", validation: validation
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/web/routes/people.rb
+++ b/apps/admin/web/routes/people.rb
@@ -1,0 +1,51 @@
+class Admin::Application < Dry::Web::Application
+  route "people" do |r|
+    r.authorize do
+      r.is do
+        r.get do
+          r.view "people.index", page: r[:page]
+        end
+
+        r.post do
+          r.resolve "admin.people.operations.create" do |create_post|
+            create_post.(r[:person]) do |m|
+              m.success do
+                flash[:notice] = t["admin.people.post_created"]
+                r.redirect "/admin/people"
+              end
+
+              m.failure do |validation|
+                r.view "people.new", validation: validation
+              end
+            end
+          end
+        end
+      end
+
+      r.get "new" do
+        r.view "people.new"
+      end
+
+      r.on ":id" do |id|
+        r.get "edit" do
+          r.view "people.edit", id: id
+        end
+
+        r.post do
+          r.resolve "admin.people.operations.update" do |update_post|
+            update_post.(id, r[:post]) do |m|
+              m.success do
+                flash[:notice] = t["admin.people.post_updated"]
+                r.redirect "/admin/people"
+              end
+
+              m.failure do |validation|
+                r.view "people.edit", id: id, post_validation: validation
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/web/routes/people.rb
+++ b/apps/admin/web/routes/people.rb
@@ -7,8 +7,8 @@ class Admin::Application < Dry::Web::Application
         end
 
         r.post do
-          r.resolve "admin.people.operations.create" do |create_post|
-            create_post.(r[:person]) do |m|
+          r.resolve "admin.people.operations.create" do |create_person|
+            create_person.(r[:person]) do |m|
               m.success do
                 flash[:notice] = t["admin.people.person_created"]
                 r.redirect "/admin/people"
@@ -32,15 +32,15 @@ class Admin::Application < Dry::Web::Application
         end
 
         r.post do
-          r.resolve "admin.people.operations.update" do |update_post|
-            update_post.(id, r[:post]) do |m|
+          r.resolve "admin.people.operations.update" do |update_person|
+            update_person.(id, r[:person]) do |m|
               m.success do
-                flash[:notice] = t["admin.people.post_updated"]
+                flash[:notice] = t["admin.people.person_updated"]
                 r.redirect "/admin/people"
               end
 
               m.failure do |validation|
-                r.view "people.edit", id: id, post_validation: validation
+                r.view "people.edit", id: id, person_validation: validation
               end
             end
           end

--- a/apps/admin/web/routes/people.rb
+++ b/apps/admin/web/routes/people.rb
@@ -10,7 +10,7 @@ class Admin::Application < Dry::Web::Application
           r.resolve "admin.people.operations.create" do |create_post|
             create_post.(r[:person]) do |m|
               m.success do
-                flash[:notice] = t["admin.people.post_created"]
+                flash[:notice] = t["admin.people.person_created"]
                 r.redirect "/admin/people"
               end
 

--- a/apps/admin/web/routes/uploads.rb
+++ b/apps/admin/web/routes/uploads.rb
@@ -1,0 +1,15 @@
+class Admin::Application < Dry::Web::Application
+  route "uploads" do |r|
+    r.on "presign" do
+      r.post do
+        r.resolve "admin.uploads.operations.presign" do |presign|
+          presign.() do |m|
+            m.success do |payload|
+              payload
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/web/templates/layouts/shared/_nav.html.slim
+++ b/apps/admin/web/templates/layouts/shared/_nav.html.slim
@@ -4,9 +4,14 @@ nav.nav.nav-aware role="nav"
       h2.nav-group__header Admin
       .nav-list
         a.nav-list__link href="/admin" Admin Home
-        a.nav-list__link href="/admin/users" Users
+        a.nav-list__link href="/admin/people" People
         a.nav-list__link href="/admin/posts" Posts
         a.nav-list__link href="/admin/projects" Projects
+        a.nav-list__link href="/admin/users" Users
+    .nav-group
+      h2.nav-group__header Pages
+      .nav-list
+        a.nav-list__link href="/admin/pages/about" About
     .nav-user
       .copy
         p

--- a/apps/admin/web/templates/pages/about/edit.html.slim
+++ b/apps/admin/web/templates/pages/about/edit.html.slim
@@ -1,0 +1,18 @@
+p.link-children
+  a> href="/admin" Admin
+  span.c-grey-mid
+    ' /
+    h1.h-1 = "Editing ‘About Page’"
+
+.tabs
+  span.tab.tab--active Edit about page
+.panel
+  .panel__primary
+    form action="/admin/pages/about" method="post"
+      == csrf_tag
+      input type="hidden" name="_method" value="put"
+      fieldset
+        legend.hide-visually Edit about page
+        div data-view-formalist=page_form
+      p
+        button.button.button--primary type="submit" Save changes

--- a/apps/admin/web/templates/people/_actions.html.slim
+++ b/apps/admin/web/templates/people/_actions.html.slim
@@ -1,0 +1,1 @@
+a.fl-right.button.button--primary.button--small href="/admin/people/new" Add a person

--- a/apps/admin/web/templates/people/edit.html.slim
+++ b/apps/admin/web/templates/people/edit.html.slim
@@ -4,7 +4,7 @@ p.link-children
   a> href="/admin/people" People
   span.c-grey-mid
     ' /
-    h1.h-1 = "Editing ‘#{person.full_name}’"
+    h1.h-1 = "Editing ‘#{person.name}’"
 
 .panel
   .panel__primary

--- a/apps/admin/web/templates/people/edit.html.slim
+++ b/apps/admin/web/templates/people/edit.html.slim
@@ -6,8 +6,6 @@ p.link-children
     ' /
     h1.h-1 = "Editing ‘#{person.full_name}’"
 
-.tabs
-  span.tab.tab--active Edit person
 .panel
   .panel__primary
     form action="/admin/people/#{person.id}" method="post"

--- a/apps/admin/web/templates/people/edit.html.slim
+++ b/apps/admin/web/templates/people/edit.html.slim
@@ -13,6 +13,6 @@ p.link-children
       input type="hidden" name="_method" value="put"
       fieldset
         legend.hide-visually Edit User
-        div data-view-formalist=person_form
+        div data-view-formalist=JSON.generate(person_form.to_h(csrfToken: csrf_token))
       p
         button.button.button--primary type="submit" Save changes

--- a/apps/admin/web/templates/people/edit.html.slim
+++ b/apps/admin/web/templates/people/edit.html.slim
@@ -1,0 +1,20 @@
+== actions
+
+p.link-children
+  a> href="/admin/people" People
+  span.c-grey-mid
+    ' /
+    h1.h-1 = "Editing ‘#{person.full_name}’"
+
+.tabs
+  span.tab.tab--active Edit person
+.panel
+  .panel__primary
+    form action="/admin/people/#{person.id}" method="post"
+      == csrf_tag
+      input type="hidden" name="_method" value="put"
+      fieldset
+        legend.hide-visually Edit User
+        div data-view-formalist=person_form
+      p
+        button.button.button--primary type="submit" Save changes

--- a/apps/admin/web/templates/people/index.html.slim
+++ b/apps/admin/web/templates/people/index.html.slim
@@ -9,16 +9,14 @@ h1.h-1 People
         thead
           tr
             th ID
-            th First Name
-            th Last Name
+            th Name
             th Email
             th
         tbody
           - people.each do |person|
             tr id="person-#{person.id}"
               td.f-mono = person.id
-              td = person.first_name
-              td = person.last_name
+              td = person.name
               td.f-mono = person.email
               td
                 a> href="/admin/people/#{person.id}/edit" Edit

--- a/apps/admin/web/templates/people/index.html.slim
+++ b/apps/admin/web/templates/people/index.html.slim
@@ -1,0 +1,27 @@
+== actions
+
+h1.h-1 People
+
+.panel
+  .panel__primary
+    .table.link-children
+      table
+        thead
+          tr
+            th ID
+            th Email
+            th First Name
+            th Last Name
+            th Status
+            th
+        tbody
+          - people.each do |person|
+            tr id="person-#{person.id}"
+              td.f-mono = person.id
+              td.f-mono = person.email
+              td = person.first_name
+              td = person.last_name
+              td = person.active ? "Active" : "Deactivated"
+              td
+                a> href="/admin/people/#{person.id}/edit" Edit
+                a href="/admin/people/#{person.id}/password" Change password

--- a/apps/admin/web/templates/people/index.html.slim
+++ b/apps/admin/web/templates/people/index.html.slim
@@ -25,3 +25,5 @@ h1.h-1 People
               td
                 a> href="/admin/people/#{person.id}/edit" Edit
                 a href="/admin/people/#{person.id}/password" Change password
+p
+  == paginator.pagination

--- a/apps/admin/web/templates/people/index.html.slim
+++ b/apps/admin/web/templates/people/index.html.slim
@@ -9,19 +9,17 @@ h1.h-1 People
         thead
           tr
             th ID
-            th Email
             th First Name
             th Last Name
-            th Status
+            th Email
             th
         tbody
           - people.each do |person|
             tr id="person-#{person.id}"
               td.f-mono = person.id
-              td.f-mono = person.email
               td = person.first_name
               td = person.last_name
-              td = person.active ? "Active" : "Deactivated"
+              td.f-mono = person.email
               td
                 a> href="/admin/people/#{person.id}/edit" Edit
                 a href="/admin/people/#{person.id}/password" Change password

--- a/apps/admin/web/templates/people/new.html.slim
+++ b/apps/admin/web/templates/people/new.html.slim
@@ -10,6 +10,6 @@ h1.h-1 Create person
   .panel__primary
     form action="/admin/people" method="post"
       == csrf_tag
-      div data-view-formalist=person_form
+      div data-view-formalist=JSON.generate(person_form.to_h(csrfToken: csrf_token))
       p
         button.button.button--primary type="submit" Create person

--- a/apps/admin/web/templates/people/new.html.slim
+++ b/apps/admin/web/templates/people/new.html.slim
@@ -1,0 +1,15 @@
+== actions
+
+p.link-children
+  a> href="/admin/people" People
+  span.c-grey-mid
+    ' /
+h1.h-1 Create person
+
+.panel
+  .panel__primary
+    form action="/admin/people" method="post"
+      == csrf_tag
+      div data-view-formalist=person_form
+      p
+        button.button.button--primary type="submit" Create person

--- a/apps/main/lib/main/decorators/public_person.rb
+++ b/apps/main/lib/main/decorators/public_person.rb
@@ -1,0 +1,23 @@
+require "berg/decorator"
+
+module Main
+  module Decorators
+    class PublicPerson < Berg::Decorator
+      def job_title_text
+        job_title.value
+      end
+
+      def avatar_url
+        avatar.value
+      end
+
+      def twitter_username
+        twitter.value
+      end
+
+      def website_url
+        website.value
+      end
+    end
+  end
+end

--- a/apps/main/lib/main/entities/person.rb
+++ b/apps/main/lib/main/entities/person.rb
@@ -4,18 +4,13 @@ module Main
   module Entities
     class Person < Dry::Types::Value
       attribute :id, Types::Strict::Int
-      attribute :first_name, Types::Strict::String
-      attribute :last_name, Types::Strict::String
+      attribute :name, Types::Strict::String
       attribute :email, Types::Strict::String
       attribute :bio, Types::Strict::String
       attribute :avatar, Types::Maybe::Strict::String
       attribute :job_title, Types::Maybe::Strict::String
       attribute :twitter, Types::Maybe::Strict::String
       attribute :website, Types::Maybe::Strict::String
-
-      def full_name
-        "#{first_name} #{last_name}"
-      end
     end
   end
 end

--- a/apps/main/lib/main/entities/person.rb
+++ b/apps/main/lib/main/entities/person.rb
@@ -7,6 +7,11 @@ module Main
       attribute :first_name, Types::Strict::String
       attribute :last_name, Types::Strict::String
       attribute :email, Types::Strict::String
+      attribute :bio, Types::Strict::String
+      attribute :avatar, Types::Maybe::Strict::String
+      attribute :job_title, Types::Maybe::Strict::String
+      attribute :twitter, Types::Maybe::Strict::String
+      attribute :website, Types::Maybe::Strict::String
 
       def full_name
         "#{first_name} #{last_name}"

--- a/apps/main/lib/main/entities/person.rb
+++ b/apps/main/lib/main/entities/person.rb
@@ -1,0 +1,16 @@
+require "types"
+
+module Main
+  module Entities
+    class Person < Dry::Types::Value
+      attribute :id, Types::Strict::Int
+      attribute :first_name, Types::Strict::String
+      attribute :last_name, Types::Strict::String
+      attribute :email, Types::Strict::String
+
+      def full_name
+        "#{first_name} #{last_name}"
+      end
+    end
+  end
+end

--- a/apps/main/lib/main/entities/post.rb
+++ b/apps/main/lib/main/entities/post.rb
@@ -1,5 +1,5 @@
 require "types"
-require "main/entities/user"
+require "main/entities/person"
 
 module Main
   module Entities
@@ -12,11 +12,11 @@ module Main
       attribute :teaser, Types::Strict::String
       attribute :slug, Types::Strict::String
       attribute :status, Status
-      attribute :author_id, Types::Strict::Int
+      attribute :person_id, Types::Strict::Int
       attribute :published_at, Types::Strict::Time
 
       class WithAuthor < Post
-        attribute :author, "main.entities.user"
+        attribute :author, "main.entities.person"
       end
     end
   end

--- a/apps/main/lib/main/persistence/repositories/about_page_people.rb
+++ b/apps/main/lib/main/persistence/repositories/about_page_people.rb
@@ -1,0 +1,18 @@
+require "berg/repository"
+require "main/entities/person"
+
+module Main
+  module Persistence
+    module Repositories
+      class AboutPagePeople < Berg::Repository[:about_page_people]
+        relations :about_page_people, :people
+
+        def all_people
+          people
+            .about_page_people
+            .as(Entities::Person)
+        end
+      end
+    end
+  end
+end

--- a/apps/main/lib/main/persistence/repositories/about_page_people.rb
+++ b/apps/main/lib/main/persistence/repositories/about_page_people.rb
@@ -5,11 +5,11 @@ module Main
   module Persistence
     module Repositories
       class AboutPagePeople < Berg::Repository[:about_page_people]
-        relations :about_page_people, :people
+        relations :people
 
         def all_people
           people
-            .about_page_people
+            .for_about_page
             .as(Entities::Person)
         end
       end

--- a/apps/main/lib/main/persistence/repositories/people.rb
+++ b/apps/main/lib/main/persistence/repositories/people.rb
@@ -4,10 +4,10 @@ require "main/entities/person"
 module Main
   module Persistence
     module Repositories
-      class AboutPagePeople < Berg::Repository[:about_page_people]
+      class People < Berg::Repository[:people]
         relations :people
 
-        def all_people
+        def for_about_page
           people
             .for_about_page
             .as(Entities::Person)

--- a/apps/main/lib/main/persistence/repositories/posts.rb
+++ b/apps/main/lib/main/persistence/repositories/posts.rb
@@ -5,12 +5,12 @@ module Main
   module Persistence
     module Repositories
       class Posts < Berg::Repository[:posts]
-        relations :posts, :users
+        relations :posts, :people
 
         def by_slug(slug)
           posts
           .by_slug(slug)
-          .combine(one: { author: [users, author_id: :id] })
+          .combine(one: { author: [people, person_id: :id] })
           .as(Entities::Post::WithAuthor).one
         end
 
@@ -20,7 +20,7 @@ module Main
             .per_page(per_page)
             .page(page)
             .order(:published_at)
-            .combine(one: { author: [users, author_id: :id] })
+            .combine(one: { author: [people, person_id: :id] })
             .as(Entities::Post::WithAuthor)
         end
       end

--- a/apps/main/lib/main/views/pages/about.rb
+++ b/apps/main/lib/main/views/pages/about.rb
@@ -6,7 +6,7 @@ module Main
     module Pages
       class About < Main::View
         include Main::Import(
-          "main.persistence.repositories.about_page_people"
+          "main.persistence.repositories.people"
         )
 
         configure do |config|
@@ -15,7 +15,7 @@ module Main
 
         def locals(options = {})
           super.merge(
-            about_page_people: about_page_people.all_people,
+            people: people.for_about_page,
           )
         end
       end

--- a/apps/main/lib/main/views/pages/about.rb
+++ b/apps/main/lib/main/views/pages/about.rb
@@ -1,5 +1,6 @@
 require "main/import"
 require "main/view"
+require "main/decorators/public_person"
 
 module Main
   module Views
@@ -15,7 +16,7 @@ module Main
 
         def locals(options = {})
           super.merge(
-            people: people.for_about_page,
+            people: Decorators::PublicPerson.decorate(people.for_about_page),
           )
         end
       end

--- a/apps/main/lib/main/views/pages/about.rb
+++ b/apps/main/lib/main/views/pages/about.rb
@@ -1,0 +1,24 @@
+require "main/import"
+require "main/view"
+
+module Main
+  module Views
+    module Pages
+      class About < Main::View
+        include Main::Import(
+          "main.persistence.repositories.about_page_people"
+        )
+
+        configure do |config|
+          config.template = "pages/about"
+        end
+
+        def locals(options = {})
+          super.merge(
+            about_page_people: about_page_people.all_people,
+          )
+        end
+      end
+    end
+  end
+end

--- a/apps/main/web/routes/pages.rb
+++ b/apps/main/web/routes/pages.rb
@@ -1,7 +1,7 @@
 module Main
   class Application < Dry::Web::Application
-    route "example" do |r|
-      # Routes go here
+    route "about" do |r|
+      r.view "pages.about"
     end
   end
 end

--- a/apps/main/web/templates/pages/about.html.slim
+++ b/apps/main/web/templates/pages/about.html.slim
@@ -2,7 +2,7 @@ ul
   - people.each do |person|
     li
       p= person.avatar_url
-      p= person.full_name
+      p= person.name
       p= person.job_title_text
       p= person.bio
       a href="http://twitter.com/#{person.twitter_username}"

--- a/apps/main/web/templates/pages/about.html.slim
+++ b/apps/main/web/templates/pages/about.html.slim
@@ -1,3 +1,8 @@
 ul
-- people.each do |person|
- li = person.full_name
+  - people.each do |person|
+    li
+      p= person.avatar_url
+      p= person.full_name
+      p= person.job_title_text
+      p= person.bio
+      a href="http://twitter.com/#{person.twitter_username}"

--- a/apps/main/web/templates/pages/about.html.slim
+++ b/apps/main/web/templates/pages/about.html.slim
@@ -1,3 +1,3 @@
 ul
-- about_page_people.each do |person|
+- people.each do |person|
  li = person.full_name

--- a/apps/main/web/templates/pages/about.html.slim
+++ b/apps/main/web/templates/pages/about.html.slim
@@ -1,0 +1,3 @@
+ul
+- about_page_people.each do |person|
+ li = person.full_name

--- a/apps/main/web/templates/posts/_snippet.html.slim
+++ b/apps/main/web/templates/posts/_snippet.html.slim
@@ -1,6 +1,6 @@
 a href="/posts/#{post.slug}" =post.title
 br
-= post.author.full_name
+= post.author.name
 br
 = post.teaser
 br

--- a/apps/main/web/templates/posts/show.html.slim
+++ b/apps/main/web/templates/posts/show.html.slim
@@ -1,12 +1,12 @@
 h1== post.title
-p== "By #{post.author.full_name} &middot; #{post.published_date}"
+p== "By #{post.author.name} &middot; #{post.published_date}"
 
 div.post
   == post.body
 
 div.author-details
   h3 Author
-  == post.author.full_name
+  == post.author.name
   / == post.author.avatar
   / == post.author.bio
 

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -3,6 +3,7 @@ development: &base
   database_url: "postgres://localhost/berg_development"
   assets_server_url: "http://localhost:8080"
   admin_url: "http://localhost:3000/admin"
+  canonical_domain: "http://localhost:3000"
   precompiled_assets: false
   precompiled_assets_host:
   app_mailer_from_email: "hello@berg.dev"
@@ -11,6 +12,9 @@ development: &base
   postmark_api_key:
   basic_auth_user:
   basic_auth_password:
+  attache_uploads_base_url: "http://berg.attache.icelab.com.au"
+  attache_downloads_base_url: "http://berg.attache.icelab.com.au"
+  attache_secret_key: "xxx"
 test:
   <<: *base
   database_url: "postgres://localhost/berg_test"

--- a/core/berg/persistence.rb
+++ b/core/berg/persistence.rb
@@ -7,6 +7,10 @@ Berg::Container.namespace "persistence" do |container|
     container["persistence.rom"].command(:users)[:create]
   end
 
+  container.register "commands.create_person" do
+    container["persistence.rom"].command(:people)[:create]
+  end
+
   container.register "commands.update_post" do
     container["persistence.rom"].command(:posts)[:update]
   end

--- a/core/berg/persistence.rb
+++ b/core/berg/persistence.rb
@@ -10,4 +10,8 @@ Berg::Container.namespace "persistence" do |container|
   container.register "commands.update_post" do
     container["persistence.rom"].command(:posts)[:update]
   end
+
+  container.register "commands.update_about_page_people" do
+    container["persistence.rom"].command(:about_page_people)[:update]
+  end
 end

--- a/db/migrate/20160525000818_create_people.rb
+++ b/db/migrate/20160525000818_create_people.rb
@@ -1,0 +1,32 @@
+ROM::SQL.migration do
+  up do
+    create_table :people do
+      primary_key :id
+      String :first_name, null: false
+      String :last_name, null: false
+      String :twitter, null: true
+      String :email, null: false
+      String :bio, null: false
+      String :website, null: true
+      String :avatar, null: true
+      String :job_title, null: true
+      TrueClass :active, null: false, default: true
+      DateTime :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+      DateTime :updated_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+    end
+
+    run <<-SQL
+      CREATE TRIGGER set_updated_at_on_people
+        BEFORE UPDATE ON people FOR EACH ROW
+        EXECUTE PROCEDURE set_updated_at_column();
+    SQL
+  end
+
+  down do
+    run <<-SQL
+      DROP TRIGGER IF EXISTS set_updated_at_on_people ON people;
+    SQL
+
+    drop_table :people
+  end
+end

--- a/db/migrate/20160525000818_create_people.rb
+++ b/db/migrate/20160525000818_create_people.rb
@@ -10,7 +10,6 @@ ROM::SQL.migration do
       String :website, null: true
       String :avatar, null: true
       String :job_title, null: true
-      TrueClass :active, null: false, default: true
       DateTime :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
       DateTime :updated_at, null: false, default: Sequel::CURRENT_TIMESTAMP
     end

--- a/db/migrate/20160525001041_create_about_page_people.rb
+++ b/db/migrate/20160525001041_create_about_page_people.rb
@@ -1,0 +1,12 @@
+ROM::SQL.migration do
+  up do
+    create_table :about_page_people do
+      Integer :position, null: false
+      Integer :person_id, null: false
+    end
+  end
+
+  down do
+    drop_table :about_page_people
+  end
+end

--- a/db/migrate/20160526014722_add_short_bio_to_people.rb
+++ b/db/migrate/20160526014722_add_short_bio_to_people.rb
@@ -1,0 +1,9 @@
+ROM::SQL.migration do
+  up do
+    add_column :people, :short_bio, String, null: false, default: ""
+  end
+
+  down do
+    drop_column :people, :short_bio
+  end
+end

--- a/db/migrate/20160526040146_rename_user_id_on_posts_to_person_id.rb
+++ b/db/migrate/20160526040146_rename_user_id_on_posts_to_person_id.rb
@@ -1,0 +1,9 @@
+ROM::SQL.migration do
+  up do
+    rename_column :posts, :author_id, :person_id
+  end
+
+  down do
+    rename_column :posts, :person_id, :author_id
+  end
+end

--- a/db/migrate/20160529234530_combine_first_name_and_last_name.rb
+++ b/db/migrate/20160529234530_combine_first_name_and_last_name.rb
@@ -1,0 +1,19 @@
+ROM::SQL.migration do
+  up do
+    add_column :people, :name, String, null: false, default: ""
+
+    run <<-SQL
+      UPDATE people SET name = CONCAT(first_name, ' ', last_name);
+    SQL
+
+    drop_column :people, :first_name
+    drop_column :people, :last_name
+  end
+
+  down do
+    add_column :people, :first_name, String, null: false, default: ""
+    add_column :people, :last_name, String, null: false, default: ""
+
+    drop_column :people, :name
+  end
+end

--- a/db/sample_data.rb
+++ b/db/sample_data.rb
@@ -52,8 +52,7 @@ create_user(
 
 create_person(
   email: "person@icelab.com.au",
-  first_name: "Icelab",
-  last_name: "Person",
+  name: "Icelab Person",
   bio: "An icelab person",
   short_bio: "An icelab person"
 )

--- a/db/sample_data.rb
+++ b/db/sample_data.rb
@@ -19,6 +19,12 @@ def create_user(attrs)
   end
 end
 
+def create_person(attrs)
+  if !admin["admin.persistence.repositories.people"].by_email(attrs[:email])
+    admin["admin.people.operations.create"].call(attrs).value
+  end
+end
+
 def create_post(attrs)
   if !admin["admin.persistence.repositories.posts"].by_slug(attrs[:slug])
     admin["admin.posts.operations.create"].call(attrs).value
@@ -44,7 +50,15 @@ create_user(
   active: true
 )
 
-author = admin["admin.persistence.repositories.users"].by_email("hello@icelab.com.au")
+create_person(
+  email: "person@icelab.com.au",
+  first_name: "Icelab",
+  last_name: "Person",
+  bio: "An icelab person",
+  short_bio: "An icelab person"
+)
+
+author = admin["admin.persistence.repositories.people"].by_email("person@icelab.com.au")
 
 20.times do |n|
   create_post(
@@ -52,7 +66,7 @@ author = admin["admin.persistence.repositories.users"].by_email("hello@icelab.co
     teaser: Faker::Hipster.sentence,
     body: Faker::Hipster.paragraph,
     status: "draft",
-    author_id: author.id
+    person_id: author.id
   )
 end
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -119,8 +119,6 @@ ALTER SEQUENCE categorisations_id_seq OWNED BY categorisations.id;
 
 CREATE TABLE people (
     id integer NOT NULL,
-    first_name text NOT NULL,
-    last_name text NOT NULL,
     twitter text,
     email text NOT NULL,
     bio text NOT NULL,
@@ -129,7 +127,8 @@ CREATE TABLE people (
     job_title text,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL,
-    short_bio text DEFAULT ''::text NOT NULL
+    short_bio text DEFAULT ''::text NOT NULL,
+    name text DEFAULT ''::text NOT NULL
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -127,7 +127,6 @@ CREATE TABLE people (
     website text,
     avatar text,
     job_title text,
-    active boolean DEFAULT true NOT NULL,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -44,7 +44,17 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: categories; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: about_page_people; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE about_page_people (
+    "position" integer NOT NULL,
+    person_id integer NOT NULL
+);
+
+
+--
+-- Name: categories; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE categories (
@@ -74,7 +84,7 @@ ALTER SEQUENCE categories_id_seq OWNED BY categories.id;
 
 
 --
--- Name: categorisations; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: categorisations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE categorisations (
@@ -104,7 +114,46 @@ ALTER SEQUENCE categorisations_id_seq OWNED BY categorisations.id;
 
 
 --
--- Name: posts; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: people; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE people (
+    id integer NOT NULL,
+    first_name text NOT NULL,
+    last_name text NOT NULL,
+    twitter text,
+    email text NOT NULL,
+    bio text NOT NULL,
+    website text,
+    avatar text,
+    job_title text,
+    active boolean DEFAULT true NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    updated_at timestamp without time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: people_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE people_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: people_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE people_id_seq OWNED BY people.id;
+
+
+--
+-- Name: posts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE posts (
@@ -141,7 +190,46 @@ ALTER SEQUENCE posts_id_seq OWNED BY posts.id;
 
 
 --
--- Name: que_jobs; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: projects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE projects (
+    id integer NOT NULL,
+    title text NOT NULL,
+    client text NOT NULL,
+    url text NOT NULL,
+    intro text NOT NULL,
+    body text NOT NULL,
+    tags text NOT NULL,
+    slug text NOT NULL,
+    status text DEFAULT 'draft'::text,
+    published_at timestamp without time zone,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    updated_at timestamp without time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: projects_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE projects_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: projects_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE projects_id_seq OWNED BY projects.id;
+
+
+--
+-- Name: que_jobs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE que_jobs (
@@ -183,7 +271,7 @@ ALTER SEQUENCE que_jobs_job_id_seq OWNED BY que_jobs.job_id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE schema_migrations (
@@ -192,7 +280,7 @@ CREATE TABLE schema_migrations (
 
 
 --
--- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE users (
@@ -246,7 +334,21 @@ ALTER TABLE ONLY categorisations ALTER COLUMN id SET DEFAULT nextval('categorisa
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY people ALTER COLUMN id SET DEFAULT nextval('people_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY posts ALTER COLUMN id SET DEFAULT nextval('posts_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY projects ALTER COLUMN id SET DEFAULT nextval('projects_id_seq'::regclass);
 
 
 --
@@ -264,7 +366,7 @@ ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regcl
 
 
 --
--- Name: categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY categories
@@ -272,7 +374,7 @@ ALTER TABLE ONLY categories
 
 
 --
--- Name: categorisations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: categorisations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY categorisations
@@ -280,7 +382,15 @@ ALTER TABLE ONLY categorisations
 
 
 --
--- Name: posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: people_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY people
+    ADD CONSTRAINT people_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY posts
@@ -288,7 +398,7 @@ ALTER TABLE ONLY posts
 
 
 --
--- Name: posts_slug_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: posts_slug_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY posts
@@ -296,7 +406,23 @@ ALTER TABLE ONLY posts
 
 
 --
--- Name: que_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY projects
+    ADD CONSTRAINT projects_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: projects_slug_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY projects
+    ADD CONSTRAINT projects_slug_key UNIQUE (slug);
+
+
+--
+-- Name: que_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY que_jobs
@@ -304,7 +430,7 @@ ALTER TABLE ONLY que_jobs
 
 
 --
--- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY schema_migrations
@@ -312,7 +438,7 @@ ALTER TABLE ONLY schema_migrations
 
 
 --
--- Name: users_email_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: users_email_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY users
@@ -320,7 +446,7 @@ ALTER TABLE ONLY users
 
 
 --
--- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY users
@@ -328,10 +454,24 @@ ALTER TABLE ONLY users
 
 
 --
+-- Name: set_updated_at_on_people; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_on_people BEFORE UPDATE ON people FOR EACH ROW EXECUTE PROCEDURE set_updated_at_column();
+
+
+--
 -- Name: set_updated_at_on_posts; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER set_updated_at_on_posts BEFORE UPDATE ON posts FOR EACH ROW EXECUTE PROCEDURE set_updated_at_column();
+
+
+--
+-- Name: set_updated_at_on_projects; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_on_projects BEFORE UPDATE ON projects FOR EACH ROW EXECUTE PROCEDURE set_updated_at_column();
 
 
 --
@@ -344,3 +484,4 @@ CREATE TRIGGER set_updated_at_on_users BEFORE UPDATE ON users FOR EACH ROW EXECU
 --
 -- PostgreSQL database dump complete
 --
+

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -162,7 +162,7 @@ CREATE TABLE posts (
     body text NOT NULL,
     slug text,
     status text DEFAULT 'draft'::text,
-    author_id integer NOT NULL,
+    person_id integer NOT NULL,
     published_at timestamp without time zone,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -128,7 +128,8 @@ CREATE TABLE people (
     avatar text,
     job_title text,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
-    updated_at timestamp without time zone DEFAULT now() NOT NULL
+    updated_at timestamp without time zone DEFAULT now() NOT NULL,
+    short_bio text DEFAULT ''::text NOT NULL
 );
 
 

--- a/lib/berg/config.rb
+++ b/lib/berg/config.rb
@@ -11,6 +11,7 @@ module Berg
     attribute :database_url, RequiredString
     attribute :session_secret, RequiredString
 
+    attribute :canonical_domain, Types::String
     attribute :assets_server_url, Types::String
     attribute :precompiled_assets, Types::Form::Bool # TODO: add .default(false) when dry-types allows it
     attribute :precompiled_assets_host, Types::String
@@ -22,6 +23,10 @@ module Berg
 
     attribute :basic_auth_user, Types::String
     attribute :basic_auth_password, Types::String
+
+    attribute :attache_uploads_base_url, Types::String
+    attribute :attache_downloads_base_url, Types::String
+    attribute :attache_secret_key, Types::String
 
     def self.load(root, name, env)
       path = root.join("config").join("#{name}.yml")

--- a/lib/berg/decorator.rb
+++ b/lib/berg/decorator.rb
@@ -1,0 +1,11 @@
+module Berg
+  class Decorator < SimpleDelegator
+    def self.decorate(object)
+      if object.respond_to?(:to_a)
+        object.to_a.map{ |obj| new obj }
+      else
+        new object
+      end
+    end
+  end
+end

--- a/lib/berg/form.rb
+++ b/lib/berg/form.rb
@@ -7,6 +7,8 @@ module Berg
   class Form < Formalist::Form
     setting :prefix
 
+    EMAIL_VALIDATION_REGEX = "/.+@.+\..+/i"
+
     class Result
       attr_reader :output, :prefix
 

--- a/lib/berg/form.rb
+++ b/lib/berg/form.rb
@@ -17,8 +17,12 @@ module Berg
         @prefix = prefix
       end
 
-      def to_h
-        { ast: output.to_ast, prefix: prefix }
+      def to_h(config = {})
+        if config.any?
+          { ast: output.to_ast, prefix: prefix, config: { global: config }}
+        else
+          { ast: output.to_ast, prefix: prefix }
+        end
       end
 
       def to_s

--- a/lib/berg/page.rb
+++ b/lib/berg/page.rb
@@ -18,6 +18,10 @@ module Berg
       self[:csrf_tag].()
     end
 
+    def csrf_token
+      self[:csrf_token].()
+    end
+
     def assets
       self[:assets]
     end

--- a/lib/persistence/commands/create_person.rb
+++ b/lib/persistence/commands/create_person.rb
@@ -1,0 +1,9 @@
+module Persistence
+  module Commands
+    class CreatePerson < ROM::Commands::Create[:sql]
+      relation :people
+      register_as :create
+      result :one
+    end
+  end
+end

--- a/lib/persistence/commands/update_about_page_people.rb
+++ b/lib/persistence/commands/update_about_page_people.rb
@@ -1,6 +1,7 @@
 module Persistence
   module Commands
     class UpdateAboutPagePeople < ROM::Commands::Update[:sql]
+      relation :about_page_people
       register_as :update
       result :many
 

--- a/lib/persistence/commands/update_about_page_people.rb
+++ b/lib/persistence/commands/update_about_page_people.rb
@@ -1,0 +1,29 @@
+module Persistence
+  module Commands
+    class UpdateAboutPagePeople < ROM::Commands::Update[:sql]
+      register_as :update
+      result :many
+
+      def execute(tuple)
+        if tuple[:about_page_people]
+          about_page_people.delete
+
+          about_page_people_tuples = tuple[:about_page_people].each_with_index.map do |person_id, position|
+            {
+              person_id: person_id,
+              position: position
+            }
+          end
+
+          about_page_people.multi_insert(about_page_people_tuples)
+        end
+      end
+
+      private
+
+      def about_page_people
+        relation.about_page_people
+      end
+    end
+  end
+end

--- a/lib/persistence/commands/update_about_page_people.rb
+++ b/lib/persistence/commands/update_about_page_people.rb
@@ -9,7 +9,7 @@ module Persistence
         if tuple[:about_page_people]
           about_page_people.delete
 
-          about_page_people_tuples = tuple[:about_page_people].each_with_index.map do |person_id, position|
+          about_page_people_tuples = tuple[:about_page_people].map.with_index do |person_id, position|
             {
               person_id: person_id,
               position: position

--- a/lib/persistence/relations/about_page_people.rb
+++ b/lib/persistence/relations/about_page_people.rb
@@ -1,0 +1,14 @@
+module Persistence
+  module Relations
+    class AboutPagePeople < ROM::Relation[:sql]
+      schema(:about_page_people) do
+        attribute :person_id, Types::ForeignKey(:people)
+        attribute :position, Types::Strict::Int
+
+        associate do
+          belongs :person, relation: :people
+        end
+      end
+    end
+  end
+end

--- a/lib/persistence/relations/people.rb
+++ b/lib/persistence/relations/people.rb
@@ -3,8 +3,7 @@ module Persistence
     class People < ROM::Relation[:sql]
       schema(:people) do
         attribute :id, Types::Serial
-        attribute :first_name, Types::Strict::String
-        attribute :last_name, Types::Strict::String
+        attribute :name, Types::Strict::String
         attribute :email, Types::Strict::String
         attribute :bio, Types::Strict::String
         attribute :short_bio, Types::Strict::String

--- a/lib/persistence/relations/people.rb
+++ b/lib/persistence/relations/people.rb
@@ -21,6 +21,10 @@ module Persistence
         where(id: id)
       end
 
+      def by_email(email)
+        where(email: email)
+      end
+
       def for_about_page
         select
           .inner_join(

--- a/lib/persistence/relations/people.rb
+++ b/lib/persistence/relations/people.rb
@@ -26,7 +26,6 @@ module Persistence
           .inner_join(
             :about_page_people,
             person_id: :id)
-          .where(active: true)
           .order(:position)
       end
     end

--- a/lib/persistence/relations/people.rb
+++ b/lib/persistence/relations/people.rb
@@ -7,6 +7,7 @@ module Persistence
         attribute :last_name, Types::Strict::String
         attribute :email, Types::Strict::String
         attribute :bio, Types::Strict::String
+        attribute :short_bio, Types::Strict::String
         attribute :twitter, Types::Strict::String.optional
         attribute :website, Types::Strict::String.optional
         attribute :avatar, Types::Strict::String.optional

--- a/lib/persistence/relations/people.rb
+++ b/lib/persistence/relations/people.rb
@@ -1,0 +1,38 @@
+module Persistence
+  module Relations
+    class People < ROM::Relation[:sql]
+      schema(:people) do
+        attribute :id, Types::Serial
+        attribute :first_name, Types::Strict::String
+        attribute :last_name, Types::Strict::String
+        attribute :email, Types::Strict::String
+        attribute :twitter, Types::Strict::String
+        attribute :bio, Types::Strict::String
+        attribute :website, Types::Strict::String
+        attribute :avatar, Types::Strict::String
+        attribute :job_title, Types::Strict::String
+        attribute :active, Types::Strict::Bool
+      end
+
+      use :pagination
+      per_page 20
+
+      def by_id(id)
+        where(id: id)
+      end
+
+      def active
+        where(active: true)
+      end
+
+      def about_page_people
+        select
+          .inner_join(
+            :about_page_people,
+            person_id: :id)
+          .where(active: true)
+          .order(:position)
+      end
+    end
+  end
+end

--- a/lib/persistence/relations/people.rb
+++ b/lib/persistence/relations/people.rb
@@ -6,12 +6,11 @@ module Persistence
         attribute :first_name, Types::Strict::String
         attribute :last_name, Types::Strict::String
         attribute :email, Types::Strict::String
-        attribute :twitter, Types::Strict::String
         attribute :bio, Types::Strict::String
-        attribute :website, Types::Strict::String
-        attribute :avatar, Types::Strict::String
-        attribute :job_title, Types::Strict::String
-        attribute :active, Types::Strict::Bool
+        attribute :twitter, Types::Strict::String.optional
+        attribute :website, Types::Strict::String.optional
+        attribute :avatar, Types::Strict::String.optional
+        attribute :job_title, Types::Strict::String.optional
       end
 
       use :pagination
@@ -19,10 +18,6 @@ module Persistence
 
       def by_id(id)
         where(id: id)
-      end
-
-      def active
-        where(active: true)
       end
 
       def for_about_page

--- a/lib/persistence/relations/people.rb
+++ b/lib/persistence/relations/people.rb
@@ -25,7 +25,7 @@ module Persistence
         where(active: true)
       end
 
-      def about_page_people
+      def for_about_page
         select
           .inner_join(
             :about_page_people,

--- a/lib/persistence/relations/posts.rb
+++ b/lib/persistence/relations/posts.rb
@@ -8,11 +8,11 @@ module Persistence
         attribute :body, Types::String
         attribute :slug, Types::String
         attribute :status, Types::String
-        attribute :author_id, Types::ForeignKey(:users)
+        attribute :person_id, Types::ForeignKey(:people)
         attribute :published_at, Types::Time
 
         associate do
-          belongs :author, relation: :users
+          belongs :author, relation: :people
           many :categories, through: :categorisations
         end
       end

--- a/lib/roda_plugins.rb
+++ b/lib/roda_plugins.rb
@@ -12,7 +12,8 @@ class Roda
         def page
           self.class["page"].with(
             csrf_metatag: -> { Rack::Csrf.metatag(request.env) },
-            csrf_tag: -> { Rack::Csrf.tag(request.env) }
+            csrf_tag: -> { Rack::Csrf.tag(request.env) },
+            csrf_token: -> { Rack::Csrf.token(request.env) }
           )
         end
       end

--- a/spec/admin/features/people/create_spec.rb
+++ b/spec/admin/features/people/create_spec.rb
@@ -12,8 +12,7 @@ RSpec.feature "Admin / People / Create", js: true do
 
     find("a", text: "Add a person").trigger("click")
 
-    find("#first_name").set("John")
-    find("#last_name").set("Doe")
+    find("#name").set("John Doe")
     find("#email").set("john.doe@icelab.com.au")
     find("#bio").set("A simple bio")
     find("#short_bio").set("A Short bio")
@@ -30,8 +29,7 @@ RSpec.feature "Admin / People / Create", js: true do
 
     find("a", text: "Add a person").trigger("click")
 
-    find("#first_name").set("John")
-    find("#last_name").set("Doe")
+    find("#name").set("John Doe")
     find("#bio").set("A simple bio")
     find("#short_bio").set("A short bio")
 

--- a/spec/admin/features/people/create_spec.rb
+++ b/spec/admin/features/people/create_spec.rb
@@ -1,0 +1,40 @@
+require "admin_app_helper"
+
+RSpec.feature "Admin / People / Create", js: true do
+  include_context "admin users"
+
+  background do
+    sign_in(jane.email, jane.password)
+  end
+
+  scenario "I can create a person" do
+    find("nav a", text: "People").trigger("click")
+
+    find("a", text: "Add a person").trigger("click")
+
+    find("#first_name").set("John")
+    find("#last_name").set("Doe")
+    find("#email").set("john.doe@icelab.com.au")
+    find("#bio").set("A simple bio")
+
+    find("button", text: "Create person").trigger("click")
+
+    expect(page).to have_content("Person has been created")
+
+    expect(page).to have_content("John Doe")
+  end
+
+  scenario "I can see validation errors" do
+    find("nav a", text: "People").trigger("click")
+
+    find("a", text: "Add a person").trigger("click")
+
+    find("#first_name").set("John")
+    find("#last_name").set("Doe")
+    find("#bio").set("A simple bio")
+
+    find("button", text: "Create person").trigger("click")
+
+    expect(page).to have_content("must be filled")
+  end
+end

--- a/spec/admin/features/people/create_spec.rb
+++ b/spec/admin/features/people/create_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature "Admin / People / Create", js: true do
     find("#last_name").set("Doe")
     find("#email").set("john.doe@icelab.com.au")
     find("#bio").set("A simple bio")
+    find("#short_bio").set("A Short bio")
 
     find("button", text: "Create person").trigger("click")
 
@@ -32,6 +33,7 @@ RSpec.feature "Admin / People / Create", js: true do
     find("#first_name").set("John")
     find("#last_name").set("Doe")
     find("#bio").set("A simple bio")
+    find("#short_bio").set("A short bio")
 
     find("button", text: "Create person").trigger("click")
 

--- a/spec/admin/features/people/edit_spec.rb
+++ b/spec/admin/features/people/edit_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Admin / People / Edit", js: true do
   include_context "admin people"
 
   before(:each) do
-    @person = create_person("John", "Doe", "john.doe@example.com", "A bio for John Doe")
+    @person = create_person("John Doe", "john.doe@example.com", "A bio for John Doe")
   end
 
   background do
@@ -19,8 +19,7 @@ RSpec.feature "Admin / People / Edit", js: true do
       find("a", text: "Edit").trigger("click")
     end
 
-    find("#first_name").set("Ben")
-    find("#last_name").set("Kenobi")
+    find("#name").set("Ben Kenobi")
     find("#bio").set("Jedi Master")
     find("#short_bio").set("Jedi")
 
@@ -38,9 +37,8 @@ RSpec.feature "Admin / People / Edit", js: true do
       find("a", text: "Edit").trigger("click")
     end
 
-    find("#first_name").set("Madona")
-    find("#last_name").set("")
-    find("#bio").set("Singer")
+    find("#name").set("Madona")
+    find("#bio").set("")
     find("#short_bio").set("Singer")
 
     find("button", text: "Save changes").trigger("click")

--- a/spec/admin/features/people/edit_spec.rb
+++ b/spec/admin/features/people/edit_spec.rb
@@ -1,0 +1,48 @@
+require "admin_app_helper"
+
+RSpec.feature "Admin / People / Edit", js: true do
+  include_context "admin users"
+  include_context "admin people"
+
+  before(:each) do
+    @person = create_person("John", "Doe", "john.doe@example.com", "A bio for John Doe")
+  end
+
+  background do
+    sign_in(jane.email, jane.password)
+  end
+
+  scenario "I can edit a post, and change the slug" do
+    find("nav a", text: "People").trigger("click")
+
+    within "#person-#{@person.id}" do
+      find("a", text: "Edit").trigger("click")
+    end
+
+    find("#first_name").set("Ben")
+    find("#last_name").set("Kenobi")
+    find("#bio").set("Jedi")
+
+    find("button", text: "Save changes").trigger("click")
+
+    expect(page).to have_content("Person has been updated")
+
+    expect(page).to have_content("Ben Kenobi")
+  end
+
+  scenario "I can see validation errors" do
+    find("nav a", text: "People").trigger("click")
+
+    within "#person-#{@person.id}" do
+      find("a", text: "Edit").trigger("click")
+    end
+
+    find("#first_name").set("Madona")
+    find("#last_name").set("")
+    find("#bio").set("Singer")
+
+    find("button", text: "Save changes").trigger("click")
+
+    expect(page).to have_content("must be filled")
+  end
+end

--- a/spec/admin/features/people/edit_spec.rb
+++ b/spec/admin/features/people/edit_spec.rb
@@ -21,7 +21,8 @@ RSpec.feature "Admin / People / Edit", js: true do
 
     find("#first_name").set("Ben")
     find("#last_name").set("Kenobi")
-    find("#bio").set("Jedi")
+    find("#bio").set("Jedi Master")
+    find("#short_bio").set("Jedi")
 
     find("button", text: "Save changes").trigger("click")
 
@@ -40,6 +41,7 @@ RSpec.feature "Admin / People / Edit", js: true do
     find("#first_name").set("Madona")
     find("#last_name").set("")
     find("#bio").set("Singer")
+    find("#short_bio").set("Singer")
 
     find("button", text: "Save changes").trigger("click")
 

--- a/spec/admin/features/posts/create_spec.rb
+++ b/spec/admin/features/posts/create_spec.rb
@@ -1,6 +1,7 @@
 require "admin_app_helper"
 
 RSpec.feature "Admin / Posts / Create", js: true do
+  include_context "admin people"
   include_context "admin users"
   include_context "admin categories"
 
@@ -10,7 +11,7 @@ RSpec.feature "Admin / Posts / Create", js: true do
   end
 
   # Currently Formalist appears to not add an ID to selection_field field types so we can't
-  # target #author_id - it doesn't exist
+  # target #person_id - it doesn't exist
   scenario "I can create a post, with a slug generated automatically" do
     find("nav a", text: "Posts").trigger("click")
 
@@ -52,7 +53,7 @@ RSpec.feature "Admin / Posts / Create", js: true do
     find("#title").set("A sample title")
     find("#teaser").set("A teaser for this sample article")
     find("#body").set("Some sample content for this post")
-    find("input[name='post[author_id]']", visible: false).set(jane.id)
+    find("input[name='post[person_id]']", visible: false).set(jane.id)
 
     find(:xpath, "//button[contains(@class, 'selection-field')]", match: :first).trigger("click")
     find(:xpath, "//button[contains(@class, 'selection-field__optionButton')][div='#{jane.first_name} #{jane.last_name}']").trigger("click")

--- a/spec/admin/features/posts/edit_spec.rb
+++ b/spec/admin/features/posts/edit_spec.rb
@@ -1,6 +1,7 @@
 require "admin_app_helper"
 
 RSpec.feature "Admin / Posts / Edit", js: true do
+  include_context "admin people"
   include_context "admin users"
   include_context "admin posts"
 

--- a/spec/admin/shared/app/admin_people.rb
+++ b/spec/admin/shared/app/admin_people.rb
@@ -1,8 +1,7 @@
 RSpec.shared_context "admin people" do
-  def create_person(first_name, last_name, email, bio, attrs = {})
+  def create_person(name, email, bio, attrs = {})
     Admin::Container["admin.people.operations.create"].({
-      "first_name" => first_name,
-      "last_name" => last_name,
+      "name" => name,
       "email" => email,
       "bio" => bio,
       "short_bio" => bio,
@@ -10,5 +9,5 @@ RSpec.shared_context "admin people" do
     }.merge(attrs)).value
   end
 
-  let!(:sample_person) { create_person("Jane", "Doe", "person@example.com", "bio") }
+  let!(:sample_person) { create_person("Jane Doe", "person@example.com", "bio") }
 end

--- a/spec/admin/shared/app/admin_people.rb
+++ b/spec/admin/shared/app/admin_people.rb
@@ -5,6 +5,7 @@ RSpec.shared_context "admin people" do
       "last_name" => last_name,
       "email" => email,
       "bio" => bio,
+      "short_bio" => bio,
       "active" => true
     }.merge(attrs)).value
   end

--- a/spec/admin/shared/app/admin_people.rb
+++ b/spec/admin/shared/app/admin_people.rb
@@ -9,4 +9,6 @@ RSpec.shared_context "admin people" do
       "active" => true
     }.merge(attrs)).value
   end
+
+  let!(:sample_person) { create_person("Jane", "Doe", "person@example.com", "bio") }
 end

--- a/spec/admin/shared/app/admin_people.rb
+++ b/spec/admin/shared/app/admin_people.rb
@@ -1,0 +1,11 @@
+RSpec.shared_context "admin people" do
+  def create_person(first_name, last_name, email, bio, attrs = {})
+    Admin::Container["admin.people.operations.create"].({
+      "first_name" => first_name,
+      "last_name" => last_name,
+      "email" => email,
+      "bio" => bio,
+      "active" => true
+    }.merge(attrs)).value
+  end
+end

--- a/spec/admin/shared/app/admin_posts.rb
+++ b/spec/admin/shared/app/admin_posts.rb
@@ -7,7 +7,7 @@ RSpec.shared_context "admin posts" do
       "title" => title,
       "teaser" => "A teaser for this sample post",
       "body" => "Some sample content for this post",
-      "author_id" => Admin::Container["admin.persistence.repositories.users"].by_email("jane@doe.org").id,
+      "person_id" => Admin::Container["admin.persistence.repositories.people"].by_email("person@example.com").id,
       "slug" => title.to_slug.normalize.to_s
     }.merge(attrs)).value
   end

--- a/spec/main/features/posts/index_spec.rb
+++ b/spec/main/features/posts/index_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Main / Posts / Index", js: false do
   include_context 'main posts'
 
   before do
-    author = create_person("Jane", "Doe", "person@example.com", "bio")
+    author = create_person("Jane Doe", "person@example.com", "bio")
     21.times do |i|
       create_post("foo #{i+1}", "teaser-foo-#{i+1}", "foo-#{i+1}", author)
     end

--- a/spec/main/features/posts/index_spec.rb
+++ b/spec/main/features/posts/index_spec.rb
@@ -1,13 +1,13 @@
 require "main_app_helper"
 
 RSpec.feature "Main / Posts / Index", js: false do
-
+  include_context 'main people'
   include_context 'main posts'
 
   before do
-    user = create_user(first_name: "Jane", last_name: "Doe")
+    author = create_person("Jane", "Doe", "person@example.com", "bio")
     21.times do |i|
-      create_post("foo #{i+1}", "teaser-foo-#{i+1}", "foo-#{i+1}", user)
+      create_post("foo #{i+1}", "teaser-foo-#{i+1}", "foo-#{i+1}", author)
     end
   end
 

--- a/spec/main/features/posts/show_spec.rb
+++ b/spec/main/features/posts/show_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Main / Posts / Show", js: false do
   include_context 'main posts'
 
   before do
-    author = create_person("Jane", "Doe", "person@example.com", "bio")
+    author = create_person("Jane Doe", "person@example.com", "bio")
     5.times do |i|
       create_post("foo #{i+1}", "teaser-foo-#{i+1}", "foo-#{i+1}", author)
     end
@@ -21,7 +21,7 @@ RSpec.feature "Main / Posts / Show", js: false do
   end
 
   scenario "I see a 404 page when trying to view an un-published post" do
-    author = create_person("Jane", "Doe", "person@example.com", "bio")
+    author = create_person("Jane Doe", "person@example.com", "bio")
     create_post("Secret post", "teaser", "secret-post", author, "draft")
 
     visit "/posts/secret-post"

--- a/spec/main/features/posts/show_spec.rb
+++ b/spec/main/features/posts/show_spec.rb
@@ -2,12 +2,13 @@ require "main_app_helper"
 
 RSpec.feature "Main / Posts / Show", js: false do
 
+  include_context 'main people'
   include_context 'main posts'
 
   before do
-    user = create_user(first_name: "Jane", last_name: "Doe")
+    author = create_person("Jane", "Doe", "person@example.com", "bio")
     5.times do |i|
-      create_post("foo #{i+1}", "teaser-foo-#{i+1}", "foo-#{i+1}", user)
+      create_post("foo #{i+1}", "teaser-foo-#{i+1}", "foo-#{i+1}", author)
     end
   end
 
@@ -20,8 +21,8 @@ RSpec.feature "Main / Posts / Show", js: false do
   end
 
   scenario "I see a 404 page when trying to view an un-published post" do
-    user = create_user(first_name: "John", last_name: "Doe")
-    create_post("Secret post", "teaser", "secret-post", user, "draft")
+    author = create_person("Jane", "Doe", "person@example.com", "bio")
+    create_post("Secret post", "teaser", "secret-post", author, "draft")
 
     visit "/posts/secret-post"
 

--- a/spec/main/shared/app/main_people.rb
+++ b/spec/main/shared/app/main_people.rb
@@ -1,8 +1,7 @@
 RSpec.shared_context "main people" do
-  def create_person(first_name, last_name, email, bio)
+  def create_person(name, email, bio)
     Berg::Container["persistence.commands.create_person"].({
-      first_name: first_name,
-      last_name: last_name,
+      name: name,
       email: email,
       bio: bio,
       short_bio: bio,
@@ -10,5 +9,5 @@ RSpec.shared_context "main people" do
     })
   end
 
-  # let!(:sample_person) { create_person("Jane", "Doe", "person@example.com", "bio") }
+  # let!(:sample_person) { create_person("Jane Doe", "person@example.com", "bio") }
 end

--- a/spec/main/shared/app/main_people.rb
+++ b/spec/main/shared/app/main_people.rb
@@ -1,0 +1,14 @@
+RSpec.shared_context "main people" do
+  def create_person(first_name, last_name, email, bio)
+    Berg::Container["persistence.commands.create_person"].({
+      first_name: first_name,
+      last_name: last_name,
+      email: email,
+      bio: bio,
+      short_bio: bio,
+      active: true
+    })
+  end
+
+  # let!(:sample_person) { create_person("Jane", "Doe", "person@example.com", "bio") }
+end

--- a/spec/main/shared/app/main_posts.rb
+++ b/spec/main/shared/app/main_posts.rb
@@ -13,13 +13,13 @@ RSpec.shared_context 'main posts' do
     })
   end
 
-  def create_post(title, teaser, slug, user, status="published")
+  def create_post(title, teaser, slug, person, status="published")
     Berg::Container["persistence.commands.create_post"].({
       title: title,
       body: "test",
       teaser: teaser,
       slug: title.to_slug.normalize.to_s,
-      author_id: user[:id],
+      person_id: person[:id],
       status: status,
       published_at: Time.now
     })


### PR DESCRIPTION
This PR lets us add and re-order people records for the about page

![reorder_about_page_people](https://cloud.githubusercontent.com/assets/479627/15528868/6ea27188-228b-11e6-885e-a4b2f12515e8.gif)

![screen shot 2016-05-26 at 1 02 27 pm](https://cloud.githubusercontent.com/assets/479627/15562404/2e188474-2342-11e6-922a-6489f6133444.png)

Todo:
- [x] Associate posts with people
- [x] Add rest of the require people attributes to the about page
- [x] Add tests