### PR TITLE
Mark a Project as a case study

### DIFF
--- a/apps/admin/lib/admin/entities/project.rb
+++ b/apps/admin/lib/admin/entities/project.rb
@@ -10,7 +10,7 @@ module Admin
       attribute :client, Types::Strict::String
       attribute :url, Types::Strict::String
       attribute :intro, Types::Strict::String
-      attribute :body, Types::Strict::String
+      attribute :body, Types::String
       attribute :tags, Types::Strict::String
       attribute :slug, Types::Strict::String
       attribute :status, Status

--- a/apps/admin/lib/admin/entities/project.rb
+++ b/apps/admin/lib/admin/entities/project.rb
@@ -15,6 +15,7 @@ module Admin
       attribute :slug, Types::Strict::String
       attribute :status, Status
       attribute :published_at, Types::DateTime
+      attribute :case_study, Types::Bool
 
       def deleted?
         status == "deleted"
@@ -22,6 +23,10 @@ module Admin
 
       def published?
         status == "published"
+      end
+
+      def case_study?
+        case_study == true
       end
     end
   end

--- a/apps/admin/lib/admin/projects/forms/create_form.rb
+++ b/apps/admin/lib/admin/projects/forms/create_form.rb
@@ -15,6 +15,7 @@ module Admin
           text_area :intro, label: "Introduction"
           text_area :body, label: "Body"
           text_field :tags, label: "Tags"
+          check_box :case_study, label: "Case Study", question_text: "Mark as a Case Study?"
         end
       end
     end

--- a/apps/admin/lib/admin/projects/forms/edit_form.rb
+++ b/apps/admin/lib/admin/projects/forms/edit_form.rb
@@ -20,6 +20,7 @@ module Admin
             ["draft", "Draft"], ["published", "Published"], ["deleted", "Deleted"]
           ]
           date_time_field :published_at, label: "Published at"
+          check_box :case_study, label: "Case Study", question_text: "Mark as a Case Study?"
         end
       end
     end

--- a/apps/admin/lib/admin/projects/validation/form.rb
+++ b/apps/admin/lib/admin/projects/validation/form.rb
@@ -24,14 +24,19 @@ module Admin
         required(:client).filled
         required(:url).filled
         required(:intro).filled
-        required(:body).filled
+        required(:body).maybe
         required(:tags).filled
+        required(:case_study).filled(:bool?)
 
         # Required in only the edit form
         optional(:slug).filled
         optional(:previous_slug).maybe
         optional(:status).filled(included_in?: Entities::Project::Status.values)
         optional(:published_at).maybe(:time?)
+
+        rule(body: [:body, :case_study]) do |body, case_study|
+          case_study.eql?(true).then(body.filled?)
+        end
 
         rule(slug: [:slug, :previous_slug]) do |slug, previous_slug|
           slug.not_eql?(previous_slug).then(slug.slug_unique?)

--- a/apps/admin/web/templates/projects/index.html.slim
+++ b/apps/admin/web/templates/projects/index.html.slim
@@ -10,16 +10,19 @@ h1.h-1 Projects
           tr
             th Title
             th Client
-            th Status
+            th.horizontal-align--center Status
             th.horizontal-align--center Actions
         tbody
           - projects.each do |project|
             tr id="project-#{project.slug}"
               td.vertical-align--middle
-                a href="/admin/projects/#{project.slug}/edit" = project.title
+                a> href="/admin/projects/#{project.slug}/edit" = project.title
+                - if project.case_study?
+                  .label class="label--ghost"
+                    span Case Study
               td.vertical-align--middle
                 = project.client
-              td.vertical-align--middle
+              td.horizontal-align--center.vertical-align--middle
                 .label class="label--#{project.status_class}"
                   = project.status_label
               - if project.published?
@@ -27,5 +30,6 @@ h1.h-1 Projects
                   a href="/projects/#{project.slug}" View
               - else
                 td
+
 p
   == paginator.pagination

--- a/db/migrate/20160526081129_add_case_study_to_projects.rb
+++ b/db/migrate/20160526081129_add_case_study_to_projects.rb
@@ -1,0 +1,9 @@
+ROM::SQL.migration do
+  up do
+    add_column :projects, :case_study, TrueClass, default: false, null: false
+  end
+
+  down do
+    drop_column :projects, :case_study
+  end
+end

--- a/db/migrate/20160526082400_change_projects_body_null.rb
+++ b/db/migrate/20160526082400_change_projects_body_null.rb
@@ -1,0 +1,7 @@
+ROM::SQL.migration do
+  change do
+    alter_table(:projects) do
+      set_column_allow_null :body
+    end
+  end
+end

--- a/db/sample_data.rb
+++ b/db/sample_data.rb
@@ -64,7 +64,8 @@ end
     intro: Faker::Hipster.sentence,
     body: Faker::Hipster.paragraph,
     tags: Faker::Hipster.word,
-    status: "draft"
+    status: "draft",
+    case_study: false
   )
 end
 

--- a/lib/persistence/relations/projects.rb
+++ b/lib/persistence/relations/projects.rb
@@ -12,6 +12,7 @@ module Persistence
         attribute :slug, Types::String
         attribute :status, Types::String
         attribute :published_at, Types::DateTime
+        attribute :case_study, Types::Bool
       end
 
       use :pagination

--- a/spec/admin/shared/app/admin_projects.rb
+++ b/spec/admin/shared/app/admin_projects.rb
@@ -9,7 +9,8 @@ RSpec.shared_context "admin projects" do
       "intro" => "Intro text for this example project",
       "body" => "Body content for this example project",
       "tags" => "examplepost",
-      "slug" => title.to_slug.normalize.to_s
+      "slug" => title.to_slug.normalize.to_s,
+      "case_study" => false
     }.merge(attrs)).value
   end
 


### PR DESCRIPTION
This PR adds a `:case_study` attribute to Projects so case studies can be distinguished from "regular" Projects. Case studies and regular Projects have the same required attributes with the exception of `:body` - this is only required for case studies.

This functionality was previously included in an earlier, unmerged PR (https://github.com/icelab/berg/pull/21).