### PR TITLE
Use a single :name attribute for Users

### DIFF
--- a/apps/admin/emails/account_activation.html.slim
+++ b/apps/admin/emails/account_activation.html.slim
@@ -1,4 +1,4 @@
-h1 Hello #{user.full_name}
+h1 Hello #{user.name}
 
 p
   ' Please activate your Berg account by following

--- a/apps/admin/emails/account_activation.txt.erb
+++ b/apps/admin/emails/account_activation.txt.erb
@@ -1,3 +1,3 @@
-Hello <%= user.full_name %>
+Hello <%= user.name %>
 
 Please activate your Berg account by visiting this URL: <%= user_activation_url %>

--- a/apps/admin/emails/reset_password.html.slim
+++ b/apps/admin/emails/reset_password.html.slim
@@ -1,4 +1,4 @@
-h1 Hello #{user.full_name}
+h1 Hello #{user.name}
 
 p
   ' You can reset your password by following

--- a/apps/admin/emails/reset_password.txt.erb
+++ b/apps/admin/emails/reset_password.txt.erb
@@ -1,3 +1,3 @@
-Hello <%= user.full_name %>
+Hello <%= user.name %>
 
 You can reset your Berg password by visiting this URL: <%= reset_password_url %>

--- a/apps/admin/lib/admin/entities/user.rb
+++ b/apps/admin/lib/admin/entities/user.rb
@@ -4,8 +4,7 @@ module Admin
   module Entities
     class User < Dry::Types::Value
       attribute :id, Types::Strict::Int
-      attribute :first_name, Types::Strict::String
-      attribute :last_name, Types::Strict::String
+      attribute :name, Types::Strict::String
       attribute :email, Types::Strict::String
       attribute :encrypted_password, Types::Nil | Types::Strict::String
       attribute :access_token, Types::String
@@ -13,10 +12,6 @@ module Admin
       attribute :active, Types::Bool
 
       alias_method :active?, :active
-
-      def full_name
-        "#{first_name} #{last_name}"
-      end
     end
   end
 end

--- a/apps/admin/lib/admin/users/forms/create_form.rb
+++ b/apps/admin/lib/admin/users/forms/create_form.rb
@@ -13,8 +13,7 @@ module Admin
               filled: true,
               format: EMAIL_VALIDATION_REGEX
             }
-          text_field :first_name, label: "First name"
-          text_field :last_name, label: "Last name"
+          text_field :name, label: "Name"
           check_box :active, label: "Status", question_text: "Mark as active?"
         end
       end

--- a/apps/admin/lib/admin/users/forms/edit_form.rb
+++ b/apps/admin/lib/admin/users/forms/edit_form.rb
@@ -13,8 +13,7 @@ module Admin
               filled: true,
               format: EMAIL_VALIDATION_REGEX
             }
-          text_field :first_name, label: "First name"
-          text_field :last_name, label: "Last name"
+          text_field :name, label: "Name"
           check_box :active, label: "Status", question_text: "Mark as active?"
         end
       end

--- a/apps/admin/lib/admin/users/validation/form.rb
+++ b/apps/admin/lib/admin/users/validation/form.rb
@@ -21,8 +21,7 @@ module Admin
 
         optional(:email).filled
         optional(:previous_email).maybe
-        optional(:first_name).filled
-        optional(:last_name).filled
+        optional(:name).filled
         optional(:active).filled(:bool?)
         optional(:password).filled(min_size?: 8)
 

--- a/apps/admin/web/templates/layouts/shared/_nav.html.slim
+++ b/apps/admin/web/templates/layouts/shared/_nav.html.slim
@@ -17,7 +17,7 @@ nav.nav.nav-aware role="nav"
         p
           ' You’re logged in as:
           strong.t-nowrap
-            == current_user.full_name
+            == current_user.name
 
       .nav-list
         a.nav-list__link href="#" data-view-confirm-action=JSON.generate(action: "/admin/sign-out") Log out

--- a/apps/admin/web/templates/users/edit.html.slim
+++ b/apps/admin/web/templates/users/edit.html.slim
@@ -4,7 +4,7 @@ p.link-children
   a> href="/admin/users" Users
   span.c-grey-mid
     ' /
-    h1.h-1 = "Editing ‘#{user.full_name}’"
+    h1.h-1 = "Editing ‘#{user.name}’"
 
 .tabs
   span.tab.tab--active Edit user

--- a/apps/admin/web/templates/users/index.html.slim
+++ b/apps/admin/web/templates/users/index.html.slim
@@ -10,8 +10,7 @@ h1.h-1 Users
           tr
             th ID
             th Email
-            th First Name
-            th Last Name
+            th Name
             th Status
             th
         tbody
@@ -19,8 +18,7 @@ h1.h-1 Users
             tr id="user-#{user.id}"
               td.f-mono = user.id
               td.f-mono = user.email
-              td = user.first_name
-              td = user.last_name
+              td = user.name
               td = user.active ? "Active" : "Deactivated"
               td
                 a> href="/admin/users/#{user.id}/edit" Edit

--- a/apps/admin/web/templates/users/password.html.slim
+++ b/apps/admin/web/templates/users/password.html.slim
@@ -4,7 +4,7 @@ p.link-children
   a> href="/admin/users" Users
   span.c-grey-mid
     ' /
-h2.h-1 = user.full_name
+h2.h-1 = user.name
 
 .tabs
   a.tab href="/admin/users/#{user.id}" Edit user

--- a/apps/main/lib/main/entities/user.rb
+++ b/apps/main/lib/main/entities/user.rb
@@ -4,13 +4,8 @@ module Main
   module Entities
     class User < Dry::Types::Value
       attribute :id, Types::Strict::Int
-      attribute :first_name, Types::Strict::String
-      attribute :last_name, Types::Strict::String
+      attribute :name, Types::Strict::String
       attribute :email, Types::Strict::String
-
-      def full_name
-        "#{first_name} #{last_name}"
-      end
     end
   end
 end

--- a/db/migrate/20160530061054_combine_user_first_name_and_last_name.rb
+++ b/db/migrate/20160530061054_combine_user_first_name_and_last_name.rb
@@ -1,0 +1,19 @@
+ROM::SQL.migration do
+  up do
+    add_column :users, :name, String, null: false, default: ""
+
+    run <<-SQL
+      UPDATE users SET name = CONCAT(first_name, ' ', last_name);
+    SQL
+
+    drop_column :users, :first_name
+    drop_column :users, :last_name
+  end
+
+  down do
+    add_column :users, :first_name, String, null: false, default: ""
+    add_column :users, :last_name, String, null: false, default: ""
+
+    drop_column :users, :name
+  end
+end

--- a/db/sample_data.rb
+++ b/db/sample_data.rb
@@ -45,8 +45,7 @@ end
 
 create_user(
   email: "hello@icelab.com.au",
-  first_name: "Icelab",
-  last_name: "Admin",
+  name: "Icelab Admin",
   active: true
 )
 

--- a/lib/persistence/relations/users.rb
+++ b/lib/persistence/relations/users.rb
@@ -4,8 +4,7 @@ module Persistence
       schema(:users) do
         attribute :id, Types::Serial
         attribute :email, Types::String
-        attribute :first_name, Types::String
-        attribute :last_name, Types::String
+        attribute :name, Types::String
         attribute :encrypted_password, Types::String
         attribute :active, Types::Bool
         attribute :access_token, Types::String

--- a/spec/admin/features/posts/create_spec.rb
+++ b/spec/admin/features/posts/create_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Admin / Posts / Create", js: true do
     find("#body").set("Some sample content for this post")
 
     find(:xpath, "//button[contains(@class, 'selection-field')]", match: :first).trigger("click")
-    find(:xpath, "//button[contains(@class, 'selection-field__optionButton')][div='#{jane.first_name} #{jane.last_name}']").trigger("click")
+    find(:xpath, "//button[contains(@class, 'selection-field__optionButton')][div='#{jane.name}']").trigger("click")
 
     find("button", text: "Create post").trigger("click")
 
@@ -56,7 +56,7 @@ RSpec.feature "Admin / Posts / Create", js: true do
     find("input[name='post[person_id]']", visible: false).set(jane.id)
 
     find(:xpath, "//button[contains(@class, 'selection-field')]", match: :first).trigger("click")
-    find(:xpath, "//button[contains(@class, 'selection-field__optionButton')][div='#{jane.first_name} #{jane.last_name}']").trigger("click")
+    find(:xpath, "//button[contains(@class, 'selection-field__optionButton')][div='#{jane.name}']").trigger("click")
 
     find(:xpath, "//button[contains(@class, 'multi-selection-field')]").trigger("click")
     find(:xpath, "//button[contains(@class, 'multi-selection-field__optionButton')][div='My Tag']").trigger("click")

--- a/spec/admin/features/users/create_spec.rb
+++ b/spec/admin/features/users/create_spec.rb
@@ -13,8 +13,7 @@ RSpec.feature "Admin / Users / Create", js: true do
     find("a", text: "Add a user").trigger("click")
 
     find("#email").set("jade@doe.org")
-    find("#first_name").set("Jade")
-    find("#last_name").set("Doe")
+    find("#name").set("Jade")
     check("active")
 
     find("button", text: "Create user").trigger("click")
@@ -30,8 +29,7 @@ RSpec.feature "Admin / Users / Create", js: true do
     find("a", text: "Add a user").trigger("click")
 
     find("#email").set("")
-    find("#first_name").set("Jade")
-    find("#last_name").set("Doe")
+    find("#name").set("Jade")
     check("active")
 
     find("button", text: "Create user").trigger("click")

--- a/spec/admin/shared/app/admin_people.rb
+++ b/spec/admin/shared/app/admin_people.rb
@@ -9,5 +9,5 @@ RSpec.shared_context "admin people" do
     }.merge(attrs)).value
   end
 
-  let!(:sample_person) { create_person("Jane Doe", "person@example.com", "bio") }
+  let!(:sample_person) { create_person("Jane", "person@example.com", "bio") }
 end

--- a/spec/admin/shared/app/auth.rb
+++ b/spec/admin/shared/app/auth.rb
@@ -10,8 +10,7 @@ RSpec.shared_context "admin auth" do
 
     result = Admin::Container["admin.persistence.repositories.users"].create(
       email: "#{name.downcase}@doe.org",
-      first_name: name,
-      last_name: "Doe",
+      name: name,
       active: attrs.fetch(:active) { true },
       encrypted_password: Admin::Container["core.authentication.encrypt_password"].(attrs.fetch(:password)),
       access_token: access_token.value,

--- a/spec/main/shared/app/main_posts.rb
+++ b/spec/main/shared/app/main_posts.rb
@@ -2,11 +2,10 @@ require "babosa"
 
 RSpec.shared_context 'main posts' do
 
-  def create_user(first_name: "Jane", last_name: "Doe")
+  def create_user(name: "Jane")
     Berg::Container["persistence.commands.create_user"].({
-      first_name: first_name,
-      last_name: last_name,
-      email: "#{first_name}#{Random.new.rand(100)}@#{last_name}.org",
+      name: name,
+      email: "#{name}#{Random.new.rand(100)}@example.org",
       active: true,
       access_token: "123456",
       access_token_expiration: Time.now


### PR DESCRIPTION
This PR replaces the `:first_name` and `:last_name` attributes for a User with a single `:name` attribute. 