### PR TITLE
Update note display

### DIFF
--- a/apps/admin/lib/admin/entities/person.rb
+++ b/apps/admin/lib/admin/entities/person.rb
@@ -8,7 +8,7 @@ module Admin
       attribute :email, Types::Strict::String
       attribute :bio, Types::Strict::String
       attribute :short_bio, Types::Strict::String
-      attribute :avatar_image, Types::Form::Hash
+      attribute :avatar_image, Types::Hash
       attribute :job_title, Types::Strict::String.optional
       attribute :twitter_handle, Types::Strict::String.optional
       attribute :website_url, Types::Strict::String.optional

--- a/apps/admin/lib/admin/entities/person.rb
+++ b/apps/admin/lib/admin/entities/person.rb
@@ -8,7 +8,7 @@ module Admin
       attribute :email, Types::Strict::String
       attribute :bio, Types::Strict::String
       attribute :short_bio, Types::Strict::String
-      attribute :avatar_image, Types::Hash
+      attribute :avatar_image, Types::Coercible::Hash.optional
       attribute :job_title, Types::Strict::String.optional
       attribute :twitter_handle, Types::Strict::String.optional
       attribute :website_url, Types::Strict::String.optional

--- a/apps/admin/lib/admin/entities/post.rb
+++ b/apps/admin/lib/admin/entities/post.rb
@@ -10,7 +10,7 @@ module Admin
       attribute :title, Types::Strict::String
       attribute :teaser, Types::Strict::String
       attribute :body, Types::Strict::String
-      attribute :cover_image, Types::Form::Hash
+      attribute :cover_image, Types::Hash
       attribute :slug, Types::Strict::String
       attribute :status, Status
       attribute :person_id, Types::Strict::Int

--- a/apps/admin/lib/admin/entities/post.rb
+++ b/apps/admin/lib/admin/entities/post.rb
@@ -10,6 +10,7 @@ module Admin
       attribute :title, Types::Strict::String
       attribute :teaser, Types::Strict::String
       attribute :body, Types::Strict::String
+      attribute :cover_image, Types::Form::Hash
       attribute :slug, Types::Strict::String
       attribute :status, Status
       attribute :person_id, Types::Strict::Int

--- a/apps/admin/lib/admin/people/forms/form.rb
+++ b/apps/admin/lib/admin/people/forms/form.rb
@@ -27,7 +27,7 @@ module Admin
           upload_field :avatar_image,
             label: "Avatar",
             hint: "An image of this person",
-            presign_url: "#{Berg::Container["config"].canonical_domain}/admin/uploads/presign"
+            presign_url: "/admin/uploads/presign"
 
           group label: "Social" do
             text_field :website_url, label: "Website URL", placeholder: "http://icelab.com.au", hint: "(optional)"

--- a/apps/admin/lib/admin/people/validation/form.rb
+++ b/apps/admin/lib/admin/people/validation/form.rb
@@ -26,15 +26,7 @@ module Admin
 
         required(:job_title).maybe(:str?)
         optional(:previous_email).maybe
-        required(:avatar_image).maybe(:hash?).schema do
-          optional(:original_url).maybe(:str?)
-          optional(:file_name).maybe(:str?)
-          optional(:path).maybe(:str?)
-          optional(:uid).maybe(:str?)
-          optional(:geometry).maybe(:str?)
-          optional(:type).maybe(:str?)
-          optional(:uploadURL).maybe(:str?)
-        end
+        required(:avatar_image).maybe(:hash?)
         required(:twitter_handle).maybe(:str?)
         required(:website_url).maybe(:uri?)
 

--- a/apps/admin/lib/admin/posts/forms/create_form.rb
+++ b/apps/admin/lib/admin/posts/forms/create_form.rb
@@ -31,7 +31,7 @@ module Admin
             upload_field :cover_image,
               label: "Cover Image",
               hint: "Will be displayed on the notes index page",
-              presign_url: "#{Berg::Container["config"].canonical_domain}/admin/uploads/presign"
+              presign_url: "/admin/uploads/presign"
 
           end
         end

--- a/apps/admin/lib/admin/posts/forms/create_form.rb
+++ b/apps/admin/lib/admin/posts/forms/create_form.rb
@@ -27,6 +27,12 @@ module Admin
               label: "Categories",
               selector_label: "Choose categories",
               options: dep(:categories_list)
+
+            upload_field :cover_image,
+              label: "Cover Image",
+              hint: "Will be displayed on the notes index page",
+              presign_url: "#{Berg::Container["config"].canonical_domain}/admin/uploads/presign"
+
           end
         end
 

--- a/apps/admin/lib/admin/posts/forms/edit_form.rb
+++ b/apps/admin/lib/admin/posts/forms/edit_form.rb
@@ -32,6 +32,11 @@ module Admin
               label: "Categories",
               selector_label: "Choose categories",
               options: dep(:categories_list)
+
+            upload_field :cover_image,
+              label: "Cover Image",
+              hint: "Will be displayed on the notes index page",
+              presign_url: "#{Berg::Container["config"].canonical_domain}/admin/uploads/presign"
           end
         end
 

--- a/apps/admin/lib/admin/posts/forms/edit_form.rb
+++ b/apps/admin/lib/admin/posts/forms/edit_form.rb
@@ -36,7 +36,7 @@ module Admin
             upload_field :cover_image,
               label: "Cover Image",
               hint: "Will be displayed on the notes index page",
-              presign_url: "#{Berg::Container["config"].canonical_domain}/admin/uploads/presign"
+              presign_url: "/admin/uploads/presign"
           end
         end
 

--- a/apps/admin/lib/admin/posts/validation/form.rb
+++ b/apps/admin/lib/admin/posts/validation/form.rb
@@ -24,6 +24,15 @@ module Admin
         required(:teaser).filled
         required(:body).filled
         required(:person_id).filled(:int?)
+        required(:cover_image).maybe(:hash?).schema do
+          optional(:original_url).maybe(:str?)
+          optional(:file_name).maybe(:str?)
+          optional(:path).maybe(:str?)
+          optional(:uid).maybe(:str?)
+          optional(:geometry).maybe(:str?)
+          optional(:type).maybe(:str?)
+          optional(:uploadURL).maybe(:str?)
+        end
 
         # Required in only the edit form
         optional(:slug).filled

--- a/apps/admin/lib/admin/posts/validation/form.rb
+++ b/apps/admin/lib/admin/posts/validation/form.rb
@@ -24,15 +24,7 @@ module Admin
         required(:teaser).filled
         required(:body).filled
         required(:person_id).filled(:int?)
-        required(:cover_image).maybe(:hash?).schema do
-          optional(:original_url).maybe(:str?)
-          optional(:file_name).maybe(:str?)
-          optional(:path).maybe(:str?)
-          optional(:uid).maybe(:str?)
-          optional(:geometry).maybe(:str?)
-          optional(:type).maybe(:str?)
-          optional(:uploadURL).maybe(:str?)
-        end
+        required(:cover_image).maybe(:hash?)
 
         # Required in only the edit form
         optional(:slug).filled

--- a/apps/admin/lib/admin/views/people/edit.rb
+++ b/apps/admin/lib/admin/views/people/edit.rb
@@ -21,8 +21,7 @@ module Admin
 
           super.merge(
             person: person,
-            person_form: person_form(person, validation),
-            csrf_token: options[:scope].csrf_token
+            form: person_form(person, validation)
           )
         end
 

--- a/apps/admin/lib/admin/views/people/new.rb
+++ b/apps/admin/lib/admin/views/people/new.rb
@@ -13,8 +13,7 @@ module Admin
 
         def locals(options = {})
           super.merge(
-            person_form: form_data(options[:validation]),
-            csrf_token: options[:scope].csrf_token
+            form: form_data(options[:validation])
           )
         end
 

--- a/apps/admin/lib/admin/views/posts/edit.rb
+++ b/apps/admin/lib/admin/views/posts/edit.rb
@@ -23,7 +23,7 @@ module Admin
 
           super.merge(
             post: post,
-            post_form: post_form(post, validation)
+            form: post_form(post, validation)
           )
         end
 

--- a/apps/admin/lib/admin/views/posts/new.rb
+++ b/apps/admin/lib/admin/views/posts/new.rb
@@ -13,7 +13,7 @@ module Admin
         end
 
         def locals(options = {})
-          super.merge(post_form: form_data(options[:validation]))
+          super.merge(form: form_data(options[:validation]))
         end
 
         def form_data(validation)

--- a/apps/admin/web/templates/people/edit.html.slim
+++ b/apps/admin/web/templates/people/edit.html.slim
@@ -13,6 +13,6 @@ p.link-children
       input type="hidden" name="_method" value="put"
       fieldset
         legend.hide-visually Edit User
-        div data-view-formalist=JSON.generate(person_form.to_h(csrfToken: csrf_token))
+        div data-view-formalist=JSON.generate(form.to_h(csrfToken: csrf_token))
       p
         button.button.button--primary type="submit" Save changes

--- a/apps/admin/web/templates/people/new.html.slim
+++ b/apps/admin/web/templates/people/new.html.slim
@@ -10,6 +10,6 @@ h1.h-1 Create person
   .panel__primary
     form action="/admin/people" method="post"
       == csrf_tag
-      div data-view-formalist=JSON.generate(person_form.to_h(csrfToken: csrf_token))
+      div data-view-formalist=JSON.generate(form.to_h(csrfToken: csrf_token))
       p
         button.button.button--primary type="submit" Create person

--- a/apps/admin/web/templates/posts/edit.html.slim
+++ b/apps/admin/web/templates/posts/edit.html.slim
@@ -13,6 +13,6 @@ p.link-children
       input type="hidden" name="_method" value="put"
       fieldset
         legend.hide-visually Edit Post
-        div data-view-formalist=post_form
+        div data-view-formalist=JSON.generate(form.to_h(csrfToken: csrf_token))
       p
         button.button.button--primary type="submit" Save changes

--- a/apps/admin/web/templates/posts/new.html.slim
+++ b/apps/admin/web/templates/posts/new.html.slim
@@ -10,6 +10,6 @@ h1.h-1 Create post
   .panel__primary
     form action="/admin/posts" method="post"
       == csrf_tag
-      div data-view-formalist=post_form
+      div data-view-formalist=JSON.generate(form.to_h(csrfToken: csrf_token))
       p
         button.button.button--primary type="submit" Create post

--- a/apps/main/lib/main/decorators/public_person.rb
+++ b/apps/main/lib/main/decorators/public_person.rb
@@ -7,6 +7,8 @@ module Main
         attache_url_for(avatar_image["path"], size.to_s) if avatar_image
       end
 
+      private
+
       def attache_url_for(file_path, geometry)
         prefix, basename = File.split(file_path)
         [Berg::Container["config"].attache_downloads_base_url, "view", prefix, CGI.escape(geometry), CGI.escape(basename)].join('/')

--- a/apps/main/lib/main/decorators/public_person.rb
+++ b/apps/main/lib/main/decorators/public_person.rb
@@ -4,7 +4,7 @@ module Main
   module Decorators
     class PublicPerson < Berg::Decorator
       def avatar_url(size="original")
-        attache_url_for(avatar_image["path"], size.to_s) if avatar_image.any?
+        attache_url_for(avatar_image["path"], size.to_s) if avatar_image
       end
 
       private

--- a/apps/main/lib/main/decorators/public_person.rb
+++ b/apps/main/lib/main/decorators/public_person.rb
@@ -4,7 +4,7 @@ module Main
   module Decorators
     class PublicPerson < Berg::Decorator
       def avatar_url(size="original")
-        attache_url_for(avatar_image["path"], size.to_s) if avatar_image
+        attache_url_for(avatar_image["path"], size.to_s) if avatar_image.any?
       end
 
       private

--- a/apps/main/lib/main/decorators/public_post.rb
+++ b/apps/main/lib/main/decorators/public_post.rb
@@ -16,8 +16,8 @@ module Main
         to_html(body)
       end
 
-      def cover_image_url(size="original")
-        attache_url_for(cover_image["path"], size.to_s) if cover_image
+      def cover_image_url
+        attache_url_for(cover_image["path"], 128) if cover_image
       end
 
       private

--- a/apps/main/lib/main/decorators/public_post.rb
+++ b/apps/main/lib/main/decorators/public_post.rb
@@ -17,7 +17,7 @@ module Main
       end
 
       def cover_image_url(size="original")
-        attache_url_for(cover_image["path"], size.to_s) if cover_image.any?
+        attache_url_for(cover_image["path"], size.to_s) if cover_image
       end
 
       private

--- a/apps/main/lib/main/decorators/public_post.rb
+++ b/apps/main/lib/main/decorators/public_post.rb
@@ -16,7 +16,16 @@ module Main
         to_html(body)
       end
 
+      def cover_image_url(size="original")
+        attache_url_for(cover_image["path"], size.to_s) unless cover_image.empty?
+      end
+
       private
+
+      def attache_url_for(file_path, geometry)
+        prefix, basename = File.split(file_path)
+        [Berg::Container["config"].attache_downloads_base_url, "view", prefix, CGI.escape(geometry), CGI.escape(basename)].join('/')
+      end
 
       def to_html(input)
         markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, footnotes: true, hard_wrap: true)

--- a/apps/main/lib/main/decorators/public_post.rb
+++ b/apps/main/lib/main/decorators/public_post.rb
@@ -17,7 +17,7 @@ module Main
       end
 
       def cover_image_url(size="original")
-        attache_url_for(cover_image["path"], size.to_s) unless cover_image.empty?
+        attache_url_for(cover_image["path"], size.to_s) if cover_image.any?
       end
 
       private
@@ -28,7 +28,7 @@ module Main
       end
 
       def to_html(input)
-        markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, footnotes: true, hard_wrap: true)
+        markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, footnotes: true, hard_wrap: true, fenced_code_blocks: true, tables: true, underline:true, no_intra_emphasis: true)
         markdown.render(input)
       end
     end

--- a/apps/main/lib/main/entities/person.rb
+++ b/apps/main/lib/main/entities/person.rb
@@ -7,7 +7,7 @@ module Main
       attribute :name, Types::Strict::String
       attribute :email, Types::Strict::String
       attribute :bio, Types::Strict::String
-      attribute :avatar_image, Types::Form::Hash
+      attribute :avatar_image, Types::Coercible::Hash
       attribute :job_title, Types::Strict::String.optional
       attribute :twitter_handle, Types::Strict::String.optional
       attribute :website_url, Types::Strict::String.optional

--- a/apps/main/lib/main/entities/person.rb
+++ b/apps/main/lib/main/entities/person.rb
@@ -7,7 +7,7 @@ module Main
       attribute :name, Types::Strict::String
       attribute :email, Types::Strict::String
       attribute :bio, Types::Strict::String
-      attribute :avatar_image, Types::Coercible::Hash
+      attribute :avatar_image, Types::Hash
       attribute :job_title, Types::Strict::String.optional
       attribute :twitter_handle, Types::Strict::String.optional
       attribute :website_url, Types::Strict::String.optional

--- a/apps/main/lib/main/entities/post.rb
+++ b/apps/main/lib/main/entities/post.rb
@@ -10,6 +10,7 @@ module Main
       attribute :id, Types::Strict::Int
       attribute :title, Types::Strict::String
       attribute :body, Types::Strict::String
+      attribute :cover_image, Types::Form::Hash
       attribute :teaser, Types::Strict::String
       attribute :slug, Types::Strict::String
       attribute :status, Status

--- a/apps/main/lib/main/entities/post.rb
+++ b/apps/main/lib/main/entities/post.rb
@@ -10,7 +10,7 @@ module Main
       attribute :id, Types::Strict::Int
       attribute :title, Types::Strict::String
       attribute :body, Types::Strict::String
-      attribute :cover_image, Types::Coercible::Hash
+      attribute :cover_image, Types::Hash
       attribute :teaser, Types::Strict::String
       attribute :slug, Types::Strict::String
       attribute :status, Status

--- a/apps/main/lib/main/entities/post.rb
+++ b/apps/main/lib/main/entities/post.rb
@@ -10,7 +10,7 @@ module Main
       attribute :id, Types::Strict::Int
       attribute :title, Types::Strict::String
       attribute :body, Types::Strict::String
-      attribute :cover_image, Types::Form::Hash
+      attribute :cover_image, Types::Coercible::Hash
       attribute :teaser, Types::Strict::String
       attribute :slug, Types::Strict::String
       attribute :status, Status

--- a/apps/main/web/templates/posts/_snippet.html.slim
+++ b/apps/main/web/templates/posts/_snippet.html.slim
@@ -6,3 +6,5 @@ article data-test-color=post.color
   = post.teaser
   br
   = post.published_date
+
+  img src= post.cover_image_url(128)

--- a/apps/main/web/templates/posts/_snippet.html.slim
+++ b/apps/main/web/templates/posts/_snippet.html.slim
@@ -7,4 +7,4 @@ article data-test-color=post.color
   br
   = post.published_date
 
-  img src= post.cover_image_url(128)
+  img src= post.cover_image_url

--- a/db/migrate/20160602011315_add_cover_image_to_posts.rb
+++ b/db/migrate/20160602011315_add_cover_image_to_posts.rb
@@ -1,0 +1,9 @@
+ROM::SQL.migration do
+  up do
+    add_column :posts, :cover_image, :json, default: "{}", null: true
+  end
+
+  down do
+    drop_column :posts, :cover_image, :json, default: "{}", null: true
+  end
+end

--- a/db/migrate/20160602011315_add_cover_image_to_posts.rb
+++ b/db/migrate/20160602011315_add_cover_image_to_posts.rb
@@ -1,9 +1,9 @@
 ROM::SQL.migration do
   up do
-    add_column :posts, :cover_image, :json, default: "{}", null: true
+    add_column :posts, :cover_image, :json, default: nil, null: true
   end
 
   down do
-    drop_column :posts, :cover_image, :json, default: "{}", null: true
+    drop_column :posts, :cover_image
   end
 end

--- a/db/sample_data.rb
+++ b/db/sample_data.rb
@@ -51,7 +51,11 @@ create_person(
   email: "person@icelab.com.au",
   name: "Icelab Person",
   bio: "An icelab person",
-  short_bio: "An icelab person"
+  short_bio: "An icelab person",
+  job_title: "Developer",
+  website_url: nil,
+  twitter_handle: "",
+  avatar_image: nil
 )
 
 author = admin["admin.persistence.repositories.people"].by_email("person@icelab.com.au")
@@ -63,7 +67,8 @@ author = admin["admin.persistence.repositories.people"].by_email("person@icelab.
     body: Faker::Hipster.paragraph,
     status: "published",
     person_id: author.id,
-    published_at: Time.now
+    published_at: Time.now,
+    cover_image: nil
   )
 end
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -232,7 +232,7 @@ CREATE TABLE posts (
     updated_at timestamp without time zone DEFAULT now() NOT NULL,
     teaser text DEFAULT ''::text NOT NULL,
     color text DEFAULT ''::text NOT NULL,
-    cover_image json DEFAULT '{}'::json
+    cover_image json
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -231,7 +231,8 @@ CREATE TABLE posts (
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL,
     teaser text DEFAULT ''::text NOT NULL,
-    color text DEFAULT ''::text NOT NULL
+    color text DEFAULT ''::text NOT NULL,
+    cover_image json DEFAULT '{}'::json
 );
 
 

--- a/lib/persistence/relations/posts.rb
+++ b/lib/persistence/relations/posts.rb
@@ -6,6 +6,7 @@ module Persistence
         attribute :title, Types::String
         attribute :teaser, Types::String
         attribute :body, Types::String
+        attribute :cover_image, Types::JSON
         attribute :slug, Types::String
         attribute :color, Types::String
         attribute :status, Types::String

--- a/spec/admin/shared/app/admin_posts.rb
+++ b/spec/admin/shared/app/admin_posts.rb
@@ -8,7 +8,8 @@ RSpec.shared_context "admin posts" do
       "teaser" => "A teaser for this sample post",
       "body" => "Some sample content for this post",
       "person_id" => Admin::Container["admin.persistence.repositories.people"].by_email("person@example.com").id,
-      "slug" => title.to_slug.normalize.to_s
+      "slug" => title.to_slug.normalize.to_s,
+      "cover_image" => nil
     }.merge(attrs)).value
   end
 


### PR DESCRIPTION
This PR adds a few small changes to notes.

Most  _notably_ , the ability to add a cover image which will be displayed on the notes index page. I've also updated our markdown renderer to include tables, code blocks and underlines