### PR TITLE
Rename public posts routes

### DIFF
--- a/apps/main/web/routes/posts.rb
+++ b/apps/main/web/routes/posts.rb
@@ -1,6 +1,6 @@
 module Main
   class Application < Dry::Web::Application
-    route "posts" do |r|
+    route "notes" do |r|
       r.on "category" do
         r.on ":category" do |category|
           r.view "posts.category.index", category: category, page: r[:page] || 1

--- a/apps/main/web/templates/layouts/application.html.slim
+++ b/apps/main/web/templates/layouts/application.html.slim
@@ -14,7 +14,7 @@ html
       .content__inner
         .masthead.flex-y-center
           h1.masthead__logo
-            a.masthead__logo-anchor.flex-y-center href="#"
+            a.masthead__logo-anchor.flex-y-center href="/"
               span.masthead__logo-berg.mr-small
               | Icelab
           == page.nav_main

--- a/apps/main/web/templates/layouts/shared/_nav_main.html.slim
+++ b/apps/main/web/templates/layouts/shared/_nav_main.html.slim
@@ -6,8 +6,8 @@ ul.nav-main.fl-right#main-navigation role="navigation"
   li.nav-main__item
     a.nav-main__anchor.nav-main__anchor--active href="/work" Work
   li.nav-main__item
-    a.nav-main__anchor href="#" About
+    a.nav-main__anchor href="/about" About
   li.nav-main__item
-    a.nav-main__anchor href="#" Notes
+    a.nav-main__anchor href="/notes" Notes
   li.nav-main__item
-    a.nav-main__anchor href="#" Contact
+    a.nav-main__anchor href="/contact" Contact

--- a/apps/main/web/templates/posts/_snippet.html.slim
+++ b/apps/main/web/templates/posts/_snippet.html.slim
@@ -1,5 +1,5 @@
 article data-test-color=post.color
-  a href="/posts/#{post.slug}" =post.title
+  a href="/notes/#{post.slug}" =post.title
   br
   = post.author.name
   br

--- a/apps/main/web/templates/posts/show.html.slim
+++ b/apps/main/web/templates/posts/show.html.slim
@@ -20,5 +20,5 @@ div.meta
     ul
       - post.categories.each do |category|
         li
-          a href="/posts/category/#{category.slug}"
+          a href="/notes/category/#{category.slug}"
             = category.name

--- a/apps/main/web/templates/shared/_pager_links.html.slim
+++ b/apps/main/web/templates/shared/_pager_links.html.slim
@@ -1,8 +1,8 @@
 span.prev
   - disabled_class = (current_page == 1 ? 'disabled' : '')
-  a href="/posts?page=#{prev_page}" rel="prev" class=[disabled_class]
+  a href="/notes?page=#{prev_page}" rel="prev" class=[disabled_class]
     | &lsaquo; Newer
 span.next
   - disabled_class = (current_page == total_pages ? 'disabled' : '')
-  a href="/posts?page=#{next_page}" rel="next" class=[disabled_class]
+  a href="/notes?page=#{next_page}" rel="next" class=[disabled_class]
     | Older &rsaquo;

--- a/spec/admin/features/posts/create_spec.rb
+++ b/spec/admin/features/posts/create_spec.rb
@@ -95,7 +95,7 @@ RSpec.feature "Admin / Posts / Create", js: true do
     find("input[name='post[published_at]']", visible: false).set(Time.now)
     click_button "Save changes"
 
-    visit "/posts"
+    visit "/notes"
 
     expect(page).to have_css("[data-test-color]:not([data-test-color=''])")
   end

--- a/spec/main/features/posts/index_spec.rb
+++ b/spec/main/features/posts/index_spec.rb
@@ -13,17 +13,17 @@ RSpec.feature "Main / Posts / Index", js: false do
   end
 
   scenario "I can view a list of posts" do
-    visit "/posts"
+    visit "/notes"
 
     expect(page).to have_content("foo 1")
   end
 
   scenario "I can paginate through the list of posts" do
-    visit "/posts"
+    visit "/notes"
 
     expect(page).to have_content("Older")
     expect(page).to have_content("Newer")
-    expect(page).to_not have_css("a[href='/posts/foo-1']")
+    expect(page).to_not have_css("a[href='/notes/foo-1']")
 
     click_link("Older", :match => :first)
 
@@ -35,13 +35,13 @@ RSpec.feature "Main / Posts / Index", js: false do
     post = create_post("A Ruby Post", "it'll be good", "a-ruby-post", @author)
     categorise_post(category[:id], post[:id])
 
-    visit "/posts/category/ruby"
+    visit "/notes/category/ruby"
 
     expect(page).to have_content "A Ruby Post"
   end
 
   scenario "I see the 404 page if I try view a category that doesn't exist" do
-    visit "/posts/category/rb"
+    visit "/notes/category/rb"
 
     expect(page).to have_content "Oops! We couldn’t find this page."
   end

--- a/spec/main/features/posts/show_spec.rb
+++ b/spec/main/features/posts/show_spec.rb
@@ -13,10 +13,10 @@ RSpec.feature "Main / Posts / Show", js: false do
   end
 
   scenario "I can view a post's detail page" do
-    visit "/posts"
+    visit "/notes"
     click_link "foo 1"
 
-    expect(page.current_path).to eq "/posts/foo-1"
+    expect(page.current_path).to eq "/notes/foo-1"
     expect(page).to have_content "test"
   end
 
@@ -24,9 +24,9 @@ RSpec.feature "Main / Posts / Show", js: false do
     author = create_person("Jane Doe", "person@example.com", "bio")
     create_post("Secret post", "teaser", "secret-post", author, "draft")
 
-    visit "/posts/secret-post"
+    visit "/notes/secret-post"
 
-    expect(page.current_path).to eq "/posts/secret-post"
+    expect(page.current_path).to eq "/notes/secret-post"
     expect(page).to have_content "Oops! We couldn’t find this page."
   end
 end


### PR DESCRIPTION
This PR modifies the routes for public Posts, so these are nested under the `/notes` path.

For example: `http:://icelab.com.au/notes/my-past-and-future-ruby`.
