### PR TITLE
Add highlight colour to Home Page Featured Items

### DIFF
--- a/apps/admin/lib/admin/pages/home/forms/edit_form.rb
+++ b/apps/admin/lib/admin/pages/home/forms/edit_form.rb
@@ -25,9 +25,12 @@ module Admin
                 text_field :url,
                   label: "URL"
 
+                text_field :highlight_color,
+                  label: "Highlight Colour",
+                  placeholder: "Six-digit hexadecimal code"
+
                 upload_field :cover_image,
                   label: "Cover Image",
-                  hint: "A cover image for this item",
                   presign_url: "/admin/uploads/presign"
               end
           end

--- a/apps/admin/lib/admin/pages/home/forms/edit_form.rb
+++ b/apps/admin/lib/admin/pages/home/forms/edit_form.rb
@@ -27,7 +27,10 @@ module Admin
 
                 text_field :highlight_color,
                   label: "Highlight Colour",
-                  placeholder: "Six-digit hexadecimal code"
+                  placeholder: "Six-digit hexadecimal code, without the leading #",
+                  validation: {
+                    format: "/^([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$/"
+                  }
 
                 upload_field :cover_image,
                   label: "Cover Image",

--- a/apps/admin/lib/admin/pages/home/validation/form.rb
+++ b/apps/admin/lib/admin/pages/home/validation/form.rb
@@ -15,6 +15,7 @@ module Admin
             required(:description).filled
             required(:url).filled
             required(:cover_image).filled
+            required(:highlight_color).filled
           end
         end
       end

--- a/apps/admin/lib/admin/pages/work/forms/edit_form.rb
+++ b/apps/admin/lib/admin/pages/work/forms/edit_form.rb
@@ -27,7 +27,6 @@ module Admin
 
                 upload_field :cover_image,
                   label: "Cover Image",
-                  hint: "A cover image for this item",
                   presign_url: "/admin/uploads/presign"
                 end
           end

--- a/apps/main/lib/main/entities/home_page_featured_item.rb
+++ b/apps/main/lib/main/entities/home_page_featured_item.rb
@@ -9,7 +9,7 @@ module Main
       attribute :description, Types::Strict::String
       attribute :url, Types::Strict::String
       attribute :cover_image, Types::Hash
-      attribute :background_color, Types::Strict::String
+      attribute :highlight_color, Types::Strict::String
 
       def cover_image_url(size = "original")
         attache_url_for(cover_image["path"], size.to_s) if cover_image

--- a/apps/main/lib/main/entities/home_page_featured_item.rb
+++ b/apps/main/lib/main/entities/home_page_featured_item.rb
@@ -9,6 +9,7 @@ module Main
       attribute :description, Types::Strict::String
       attribute :url, Types::Strict::String
       attribute :cover_image, Types::Hash
+      attribute :background_color, Types::Strict::String
 
       def cover_image_url(size = "original")
         attache_url_for(cover_image["path"], size.to_s) if cover_image

--- a/apps/main/web/templates/pages/home.html.slim
+++ b/apps/main/web/templates/pages/home.html.slim
@@ -13,4 +13,5 @@ ul
     li
       p = featured_item.title
       p = featured_item.description
+      p = featured_item.highlight_color
       p = featured_item.cover_image_url

--- a/db/migrate/20160606015727_add_highlight_color_to_home_page_featured_items.rb
+++ b/db/migrate/20160606015727_add_highlight_color_to_home_page_featured_items.rb
@@ -1,0 +1,9 @@
+ROM::SQL.migration do
+  up do
+    add_column :home_page_featured_items, :highlight_color, String, null: false, default: ""
+  end
+
+  down do
+    drop_column :home_page_featured_items, :highlight_color
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -127,7 +127,8 @@ CREATE TABLE home_page_featured_items (
     title text NOT NULL,
     description text NOT NULL,
     url text NOT NULL,
-    cover_image json DEFAULT '{}'::json NOT NULL
+    cover_image json DEFAULT '{}'::json NOT NULL,
+    highlight_color text DEFAULT ''::text NOT NULL
 );
 
 

--- a/lib/persistence/commands/update_home_page_featured_items.rb
+++ b/lib/persistence/commands/update_home_page_featured_items.rb
@@ -15,7 +15,8 @@ module Persistence
               title: item[:title],
               description: item[:description],
               url: item[:url],
-              cover_image: item[:cover_image].to_json
+              cover_image: item[:cover_image].to_json,
+              highlight_color: item[:highlight_color]
             }
           end
 

--- a/lib/persistence/relations/home_page_featured_items.rb
+++ b/lib/persistence/relations/home_page_featured_items.rb
@@ -8,6 +8,7 @@ module Persistence
         attribute :description, Types::Strict::String
         attribute :url, Types::Strict::String
         attribute :cover_image, Types::Strict::Hash
+        attribute :highlight_color, Types::Strict::String
       end
     end
   end


### PR DESCRIPTION
This PR adds a `:highlight_color` attribute to Home Page Featured Items. This is used to specify the colour used for the gradient overlay atop the item's `cover_image` on the home page. 

![image](https://cloud.githubusercontent.com/assets/10018241/15811630/e0ca543e-2be5-11e6-94f7-46e62480fe38.png)
