### PR TITLE
Add basic validations to forms in the Admin

### DIFF
--- a/apps/admin/lib/admin/categories/forms/form.rb
+++ b/apps/admin/lib/admin/categories/forms/form.rb
@@ -9,14 +9,16 @@ module Admin
         prefix :category
 
         define do
-          text_field :name, label: "Name",
-          validation: {
-            filled: true
-          }
-          text_field :slug, label: "Slug",
-          validation: {
-            filled: true
-          }
+          text_field :name,
+            label: "Name",
+            validation: {
+              filled: true
+            }
+          text_field :slug,
+            label: "Slug",
+            validation: {
+              filled: true
+            }
         end
       end
     end

--- a/apps/admin/lib/admin/categories/forms/form.rb
+++ b/apps/admin/lib/admin/categories/forms/form.rb
@@ -9,8 +9,14 @@ module Admin
         prefix :category
 
         define do
-          text_field :name, label: "Name"
-          text_field :slug, label: "Slug"
+          text_field :name, label: "Name",
+          validation: {
+            filled: true
+          }
+          text_field :slug, label: "Slug",
+          validation: {
+            filled: true
+          }
         end
       end
     end

--- a/apps/admin/lib/admin/pages/contact/forms/edit_form.rb
+++ b/apps/admin/lib/admin/pages/contact/forms/edit_form.rb
@@ -11,11 +11,20 @@ module Admin
           define do
             many :office_locations do
               text_field :name,
-                label: "Location Name"
+                label: "Location Name",
+                validation: {
+                  filled: true
+                }
               text_field :address,
-                label: "Address"
+                label: "Address",
+                validation: {
+                  filled: true
+                }
               text_field :phone_number,
-                label: "Phone Number"
+                label: "Phone Number",
+                validation: {
+                  filled: true
+                }
             end
           end
         end

--- a/apps/admin/lib/admin/pages/home/forms/edit_form.rb
+++ b/apps/admin/lib/admin/pages/home/forms/edit_form.rb
@@ -17,24 +17,37 @@ module Admin
               action_label: "Add a featured item",
               placeholder: "No featured items added yet." do
                 text_field :title,
-                  label: "Title"
+                  label: "Title",
+                  validation: {
+                    filled: true
+                  }
 
                 text_field :description,
-                  label: "Description"
+                  label: "Description",
+                  validation: {
+                    filled: true
+                  }
 
                 text_field :url,
-                  label: "URL"
+                  label: "URL",
+                  validation: {
+                    filled: true
+                  }
 
                 text_field :highlight_color,
                   label: "Highlight Colour",
                   placeholder: "Six-digit hexadecimal code, without the leading #",
                   validation: {
+                    filled: true,
                     format: "/^([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$/"
                   }
 
                 upload_field :cover_image,
                   label: "Cover Image",
-                  presign_url: "/admin/uploads/presign"
+                  presign_url: "/admin/uploads/presign",
+                  validation: {
+                    filled: true
+                  }
               end
           end
         end

--- a/apps/admin/lib/admin/pages/work/forms/edit_form.rb
+++ b/apps/admin/lib/admin/pages/work/forms/edit_form.rb
@@ -17,17 +17,29 @@ module Admin
               action_label: "Add a featured item",
               placeholder: "No featured items added yet." do
                 text_field :title,
-                  label: "Title"
+                  label: "Title",
+                  validation: {
+                    filled: true
+                  }
 
                 text_field :description,
-                  label: "Description"
+                  label: "Description",
+                  validation: {
+                    filled: true
+                  }
 
                 text_field :url,
-                  label: "URL"
+                  label: "URL",
+                  validation: {
+                    filled: true
+                  }
 
                 upload_field :cover_image,
                   label: "Cover Image",
-                  presign_url: "/admin/uploads/presign"
+                  presign_url: "/admin/uploads/presign",
+                  validation: {
+                    filled: true
+                  }
                 end
           end
         end

--- a/apps/admin/lib/admin/posts/forms/create_form.rb
+++ b/apps/admin/lib/admin/posts/forms/create_form.rb
@@ -14,14 +14,26 @@ module Admin
         define do
           section :post do
             group do
-              text_field :title, label: "Title"
+              text_field :title, label: "Title",
+              validation: {
+                filled: true
+              }
             end
             group do
-              text_area :teaser, label: "Teaser"
-              selection_field :person_id, label: "Author", options: dep(:author_list)
+              text_area :teaser, label: "Teaser",
+              validation: {
+                filled: true
+              }
+              selection_field :person_id, label: "Author", options: dep(:author_list),
+              validation: {
+                filled: true
+              }
             end
 
-            text_area :body, label: "Body"
+            text_area :body, label: "Body",
+            validation: {
+              filled: true
+            }
 
             multi_selection_field :post_categories,
               label: "Categories",

--- a/apps/admin/lib/admin/posts/forms/create_form.rb
+++ b/apps/admin/lib/admin/posts/forms/create_form.rb
@@ -14,26 +14,31 @@ module Admin
         define do
           section :post do
             group do
-              text_field :title, label: "Title",
-              validation: {
-                filled: true
-              }
+              text_field :title,
+                label: "Title",
+                validation: {
+                  filled: true
+                }
             end
             group do
-              text_area :teaser, label: "Teaser",
-              validation: {
-                filled: true
-              }
-              selection_field :person_id, label: "Author", options: dep(:author_list),
-              validation: {
-                filled: true
-              }
+              text_area :teaser,
+                label: "Teaser",
+                validation: {
+                  filled: true
+                }
+              selection_field :person_id,
+                label: "Author",
+                options: dep(:author_list),
+                validation: {
+                  filled: true
+                }
             end
 
-            text_area :body, label: "Body",
-            validation: {
-              filled: true
-            }
+            text_area :body,
+              label: "Body",
+              validation: {
+                filled: true
+              }
 
             multi_selection_field :post_categories,
               label: "Categories",

--- a/apps/admin/lib/admin/posts/forms/edit_form.rb
+++ b/apps/admin/lib/admin/posts/forms/edit_form.rb
@@ -14,15 +14,30 @@ module Admin
         define do
           section :post do
             group do
-              text_field :title, label: "Title"
-              text_field :slug, label: "Slug"
+              text_field :title, label: "Title",
+              validation: {
+                filled: true
+              }
+              text_field :slug, label: "Slug",
+              validation: {
+                filled: true
+              }
             end
             group do
-              text_area :teaser, label: "Teaser"
-              selection_field :person_id, label: "Author", options: dep(:author_list)
+              text_area :teaser, label: "Teaser",
+              validation: {
+                filled: true
+              }
+              selection_field :person_id, label: "Author", options: dep(:author_list),
+              validation: {
+                filled: true
+              }
             end
 
-            text_area :body, label: "Body"
+            text_area :body, label: "Body",
+            validation: {
+              filled: true
+            }
 
             group do
               select_box :status, label: "Status", options: dep(:status_list)

--- a/apps/admin/lib/admin/posts/forms/edit_form.rb
+++ b/apps/admin/lib/admin/posts/forms/edit_form.rb
@@ -14,30 +14,36 @@ module Admin
         define do
           section :post do
             group do
-              text_field :title, label: "Title",
-              validation: {
-                filled: true
-              }
-              text_field :slug, label: "Slug",
-              validation: {
-                filled: true
-              }
+              text_field :title,
+                label: "Title",
+                validation: {
+                  filled: true
+                }
+              text_field :slug,
+                label: "Slug",
+                validation: {
+                  filled: true
+                }
             end
             group do
-              text_area :teaser, label: "Teaser",
-              validation: {
-                filled: true
-              }
-              selection_field :person_id, label: "Author", options: dep(:author_list),
-              validation: {
-                filled: true
-              }
+              text_area :teaser,
+                label: "Teaser",
+                validation: {
+                  filled: true
+                }
+              selection_field :person_id,
+                label: "Author",
+                options: dep(:author_list),
+                validation: {
+                  filled: true
+                }
             end
 
-            text_area :body, label: "Body",
-            validation: {
-              filled: true
-            }
+            text_area :body,
+              label: "Body",
+              validation: {
+                filled: true
+              }
 
             group do
               select_box :status, label: "Status", options: dep(:status_list)

--- a/apps/admin/lib/admin/posts/validation/form.rb
+++ b/apps/admin/lib/admin/posts/validation/form.rb
@@ -41,6 +41,10 @@ module Admin
         rule(published_at: [:status, :published_at]) do |status, published_at|
           status.eql?("published").then(published_at.filled?)
         end
+
+        rule(post_categories: [:status, :post_categories]) do |status, post_categories|
+          status.eql?("published").then(post_categories.filled?)
+        end
       end
     end
   end

--- a/apps/admin/lib/admin/projects/forms/create_form.rb
+++ b/apps/admin/lib/admin/projects/forms/create_form.rb
@@ -9,12 +9,36 @@ module Admin
         prefix :project
 
         define do
-          text_field :title, label: "Title"
-          text_field :client, label: "Client"
-          text_field :url, label: "URL"
-          text_area :intro, label: "Introduction"
-          text_area :body, label: "Body"
-          text_field :tags, label: "Tags"
+          text_field :title,
+            label: "Title",
+            validation: {
+              filled: true
+            }
+          text_field :client,
+            label: "Client",
+            validation: {
+              filled: true
+            }
+          text_field :url,
+            label: "URL",
+            validation: {
+              filled: true
+            }
+          text_area :intro,
+            label: "Introduction",
+            validation: {
+              filled: true
+            }
+          text_area :body,
+            label: "Body",
+            validation: {
+              filled: true
+            }
+          text_field :tags,
+            label: "Tags",
+            validation: {
+              filled: true
+            }
           check_box :case_study, label: "Case Study", question_text: "Mark as a Case Study?"
         end
       end

--- a/apps/admin/lib/admin/projects/forms/edit_form.rb
+++ b/apps/admin/lib/admin/projects/forms/edit_form.rb
@@ -9,15 +9,44 @@ module Admin
         prefix :project
 
         define do
-          text_field :title, label: "Title"
-          text_field :client, label: "Client"
-          text_field :url, label: "URL"
-          text_area :intro, label: "Introduction"
-          text_area :body, label: "Body"
-          text_field :slug, label: "Slug"
-          text_field :tags, label: "Tags"
-          select_box :status, label: "Status", options: [
-            ["draft", "Draft"], ["published", "Published"], ["deleted", "Deleted"]
+          text_field :title,
+            label: "Title",
+            validation: {
+              filled: true
+            }
+          text_field :client,
+            label: "Client",
+            validation: {
+              filled: true
+            }
+          text_field :url,
+            label: "URL",
+            validation: {
+              filled: true
+            }
+          text_area :intro,
+            label: "Introduction",
+            validation: {
+              filled: true
+            }
+          text_area :body,
+            label: "Body",
+            validation: {
+              filled: true
+            }
+          text_field :slug,
+            label: "Slug",
+            validation: {
+              filled: true
+            }
+          text_field :tags,
+            label: "Tags",
+            validation: {
+              filled: true
+            }
+          select_box :status,
+            label: "Status", options: [
+              ["draft", "Draft"], ["published", "Published"], ["deleted", "Deleted"]
           ]
           date_time_field :published_at, label: "Published at"
           check_box :case_study, label: "Case Study", question_text: "Mark as a Case Study?"

--- a/apps/admin/lib/admin/users/forms/create_form.rb
+++ b/apps/admin/lib/admin/users/forms/create_form.rb
@@ -13,7 +13,11 @@ module Admin
               filled: true,
               format: EMAIL_VALIDATION_REGEX
             }
-          text_field :name, label: "Name"
+          text_field :name,
+            label: "Name",
+            validation: {
+              filled: true
+            }
           check_box :active, label: "Status", question_text: "Mark as active?"
         end
       end

--- a/apps/admin/lib/admin/users/forms/edit_form.rb
+++ b/apps/admin/lib/admin/users/forms/edit_form.rb
@@ -13,7 +13,11 @@ module Admin
               filled: true,
               format: EMAIL_VALIDATION_REGEX
             }
-          text_field :name, label: "Name"
+          text_field :name,
+            label: "Name",
+            validation: {
+              filled: true
+            }
           check_box :active, label: "Status", question_text: "Mark as active?"
         end
       end

--- a/spec/admin/features/posts/create_spec.rb
+++ b/spec/admin/features/posts/create_spec.rb
@@ -82,6 +82,9 @@ RSpec.feature "Admin / Posts / Create", js: true do
     find(:xpath, "//button[contains(@class, 'selection-field')]", match: :first).trigger("click")
     find(:xpath, "//button[contains(@class, 'selection-field__optionButton')][div='#{jane.name}']").trigger("click")
 
+    find(:xpath, "//button[contains(@class, 'multi-selection-field')]").trigger("click")
+    find(:xpath, "//button[contains(@class, 'multi-selection-field__optionButton')][div='My Tag']").trigger("click")
+
     find("button", text: "Create post").trigger("click")
 
     expect(page).to have_content("Post has been created")


### PR DESCRIPTION
This PR adds basic `filled: true` validations to the required attributes of forms in the Admin. 

The only change to the validation schema in this PR is for Posts: at least one `post_category` is required to be selected when publishing a Post. 