### PR TITLE
Wrap login pages in a minimal layout

### DIFF
--- a/apps/admin/lib/admin/views/forgot_password.rb
+++ b/apps/admin/lib/admin/views/forgot_password.rb
@@ -4,6 +4,7 @@ module Admin
   module Views
     class ForgotPassword < Admin::View
       configure do |config|
+        config.name = "admin_minimal"
         config.template = "forgot_password"
       end
     end

--- a/apps/admin/lib/admin/views/reset_password.rb
+++ b/apps/admin/lib/admin/views/reset_password.rb
@@ -11,6 +11,7 @@ module Admin
       )
 
       configure do |config|
+        config.name = "admin_minimal"
         config.template = "reset_password"
       end
 

--- a/apps/admin/lib/admin/views/sign_in.rb
+++ b/apps/admin/lib/admin/views/sign_in.rb
@@ -4,7 +4,7 @@ module Admin
   module Views
     class SignIn < Admin::View
       configure do |config|
-        config.name = "admin"
+        config.name = "admin_minimal"
         config.template = "sign_in"
       end
     end

--- a/apps/admin/web/templates/layouts/admin_minimal.html.slim
+++ b/apps/admin/web/templates/layouts/admin_minimal.html.slim
@@ -1,0 +1,22 @@
+html lang="en"
+  head
+    meta charset="utf-8"
+    meta name="turbolinks-cache-control" content="no-cache"
+    / Inlined JS
+    script
+      == page.assets.read("admin__inline-admin-header.js")
+    / CSS
+    link rel="stylesheet" type="text/css" href=page.assets["admin__admin.css"]
+    / JS
+    script type="text/javascript" src=page.assets["admin__admin.js"]
+    title Berg — Admin
+    == page.csrf_metatag
+  body data-view-fast-click=true data-view-disable-input-zoom=true
+    == page.flash
+    == page.header_minimal
+    .page.nav-aware role="main"
+      .page__contents
+        == yield
+    / Inlined JS
+    script
+      == page.assets.read("admin__inline-admin-footer.js")

--- a/apps/admin/web/templates/layouts/shared/_header_minimal.html.slim
+++ b/apps/admin/web/templates/layouts/shared/_header_minimal.html.slim
@@ -1,0 +1,3 @@
+header.header.nav-aware role="header"
+  h1.header__name
+    a href="/admin" Berg


### PR DESCRIPTION
This PR wraps the `/sign_in`, `/forgot_password` and `/reset_password` pages in a minimal layout so as to not expose the sidebar menu. 

This addresses this issue: https://github.com/icelab/berg/issues/47