### PR TITLE
Modify featured items

### DIFF
--- a/apps/admin/lib/admin/pages/home/forms/edit_form.rb
+++ b/apps/admin/lib/admin/pages/home/forms/edit_form.rb
@@ -22,12 +22,6 @@ module Admin
                     filled: true
                   }
 
-                text_field :description,
-                  label: "Description",
-                  validation: {
-                    filled: true
-                  }
-
                 text_field :url,
                   label: "URL",
                   validation: {

--- a/apps/admin/lib/admin/pages/home/validation/form.rb
+++ b/apps/admin/lib/admin/pages/home/validation/form.rb
@@ -13,7 +13,7 @@ module Admin
           required(:home_page_featured_items).each do
             required(:title).filled
             required(:url).filled
-            required(:cover_image).filled
+            required(:cover_image).filled(:hash?)
             required(:highlight_color).filled
           end
         end

--- a/apps/admin/lib/admin/pages/home/validation/form.rb
+++ b/apps/admin/lib/admin/pages/home/validation/form.rb
@@ -12,7 +12,6 @@ module Admin
 
           required(:home_page_featured_items).each do
             required(:title).filled
-            required(:description).filled
             required(:url).filled
             required(:cover_image).filled
             required(:highlight_color).filled

--- a/apps/admin/lib/admin/pages/work/forms/edit_form.rb
+++ b/apps/admin/lib/admin/pages/work/forms/edit_form.rb
@@ -22,12 +22,6 @@ module Admin
                     filled: true
                   }
 
-                text_field :description,
-                  label: "Description",
-                  validation: {
-                    filled: true
-                  }
-
                 text_field :url,
                   label: "URL",
                   validation: {

--- a/apps/admin/lib/admin/pages/work/validation/form.rb
+++ b/apps/admin/lib/admin/pages/work/validation/form.rb
@@ -13,7 +13,7 @@ module Admin
           required(:work_page_featured_items).each do
             required(:title).filled
             required(:url).filled
-            required(:cover_image).filled
+            required(:cover_image).filled(:hash?)
           end
         end
       end

--- a/apps/admin/lib/admin/pages/work/validation/form.rb
+++ b/apps/admin/lib/admin/pages/work/validation/form.rb
@@ -12,7 +12,6 @@ module Admin
 
           required(:work_page_featured_items).each do
             required(:title).filled
-            required(:description).filled
             required(:url).filled
             required(:cover_image).filled
           end

--- a/apps/admin/lib/admin/posts/validation/form.rb
+++ b/apps/admin/lib/admin/posts/validation/form.rb
@@ -46,10 +46,6 @@ module Admin
         rule(post_categories: [:status, :post_categories]) do |status, post_categories|
           status.eql?("published").then(post_categories.filled?)
         end
-
-        rule(cover_image: [:status, :cover_image]) do |status, cover_image|
-          status.eql?("published").then(cover_image.filled?)
-        end
       end
     end
   end

--- a/apps/admin/lib/admin/posts/validation/form.rb
+++ b/apps/admin/lib/admin/posts/validation/form.rb
@@ -24,7 +24,6 @@ module Admin
         required(:teaser).filled
         required(:body).filled
         required(:person_id).filled(:int?)
-        required(:cover_image).maybe(:hash?)
 
         # Required in only the edit form
         optional(:slug).filled
@@ -34,6 +33,7 @@ module Admin
         optional(:post_categories).each(:int?)
         optional(:status).filled(included_in?: Types::PostStatus.values)
         optional(:published_at).maybe(:time?)
+        required(:cover_image).maybe(:hash?)
 
         rule(slug: [:slug, :previous_slug]) do |slug, previous_slug|
           slug.not_eql?(previous_slug).then(slug.slug_unique?)
@@ -45,6 +45,10 @@ module Admin
 
         rule(post_categories: [:status, :post_categories]) do |status, post_categories|
           status.eql?("published").then(post_categories.filled?)
+        end
+
+        rule(cover_image: [:status, :cover_image]) do |status, cover_image|
+          status.eql?("published").then(cover_image.filled?)
         end
       end
     end

--- a/apps/admin/lib/admin/projects/validation/form.rb
+++ b/apps/admin/lib/admin/projects/validation/form.rb
@@ -46,10 +46,6 @@ module Admin
         rule(published_at: [:status, :published_at]) do |status, published_at|
           status.eql?("published").then(published_at.filled?)
         end
-
-        rule(cover_image: [:status, :cover_image]) do |status, cover_image|
-          status.eql?("published").then(cover_image.filled?)
-        end
       end
     end
   end

--- a/apps/main/lib/main/entities/home_page_featured_item.rb
+++ b/apps/main/lib/main/entities/home_page_featured_item.rb
@@ -6,7 +6,6 @@ module Main
       attribute :id, Types::Strict::Int
       attribute :position, Types::Strict::Int
       attribute :title, Types::Strict::String
-      attribute :description, Types::Strict::String
       attribute :url, Types::Strict::String
       attribute :cover_image, Types::Hash
       attribute :highlight_color, Types::Strict::String

--- a/apps/main/lib/main/entities/work_page_featured_item.rb
+++ b/apps/main/lib/main/entities/work_page_featured_item.rb
@@ -6,7 +6,6 @@ module Main
       attribute :id, Types::Strict::Int
       attribute :position, Types::Strict::Int
       attribute :title, Types::Strict::String
-      attribute :description, Types::Strict::String
       attribute :url, Types::Strict::String
       attribute :cover_image, Types::Hash
 

--- a/apps/main/web/templates/pages/home.html.slim
+++ b/apps/main/web/templates/pages/home.html.slim
@@ -17,7 +17,7 @@
   - featured_items.each do |featured_item|
     a.project-feature-tile href=featured_item.url style="background-color:##{featured_item.highlight_color;}"
       .project-feature-tile__image-container
-        img.project-feature-tile__image src=featured_item.cover_image_url alt=featured_item.title
+        img.project-feature-tile__image src=featured_item.cover_image_url alt=featured_item.description
       .project-feature-tile__overlay
         .project-feature-tile__overlay-gradient style="background-image: linear-gradient(to top, ##{featured_item.highlight_color} 5%, transparent 80%);"
         h1.project-feature-tile__label

--- a/apps/main/web/templates/pages/work.html.slim
+++ b/apps/main/web/templates/pages/work.html.slim
@@ -8,7 +8,6 @@ ul
   - featured_items.each do |featured_item|
     li
       p = featured_item.title
-      p = featured_item.description
       p = featured_item.cover_image_url
 
 h2 Projects

--- a/db/migrate/20160609055722_remove_description_from_home_page_featured_items.rb
+++ b/db/migrate/20160609055722_remove_description_from_home_page_featured_items.rb
@@ -1,0 +1,9 @@
+ROM::SQL.migration do
+  up do
+    drop_column :home_page_featured_items, :description
+  end
+
+  down do
+    add_column :home_page_featured_items, :description, String, null: false
+  end
+end

--- a/db/migrate/20160609055852_remove_description_from_work_page_featured_items.rb
+++ b/db/migrate/20160609055852_remove_description_from_work_page_featured_items.rb
@@ -1,0 +1,9 @@
+ROM::SQL.migration do
+  up do
+    drop_column :work_page_featured_items, :description
+  end
+
+  down do
+    add_column :work_page_featured_items, :description, String, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -125,7 +125,6 @@ CREATE TABLE home_page_featured_items (
     id integer NOT NULL,
     "position" integer NOT NULL,
     title text NOT NULL,
-    description text NOT NULL,
     url text NOT NULL,
     cover_image json DEFAULT '{}'::json NOT NULL,
     highlight_color text DEFAULT ''::text NOT NULL
@@ -397,7 +396,6 @@ CREATE TABLE work_page_featured_items (
     id integer NOT NULL,
     "position" integer NOT NULL,
     title text NOT NULL,
-    description text NOT NULL,
     url text NOT NULL,
     cover_image json DEFAULT '{}'::json NOT NULL
 );

--- a/lib/persistence/commands/update_home_page_featured_items.rb
+++ b/lib/persistence/commands/update_home_page_featured_items.rb
@@ -13,7 +13,6 @@ module Persistence
             {
               position: position,
               title: item[:title],
-              description: item[:description],
               url: item[:url],
               cover_image: item[:cover_image].to_json,
               highlight_color: item[:highlight_color]

--- a/lib/persistence/commands/update_work_page_featured_items.rb
+++ b/lib/persistence/commands/update_work_page_featured_items.rb
@@ -13,7 +13,6 @@ module Persistence
             {
               position: position,
               title: item[:title],
-              description: item[:description],
               url: item[:url],
               cover_image: item[:cover_image].to_json
             }

--- a/lib/persistence/relations/home_page_featured_items.rb
+++ b/lib/persistence/relations/home_page_featured_items.rb
@@ -6,7 +6,7 @@ module Persistence
         attribute :position, Types::Strict::Int
         attribute :title, Types::Strict::String
         attribute :url, Types::Strict::String
-        attribute :cover_image, Types::Strict::Hash
+        attribute :cover_image, Types::JSON
         attribute :highlight_color, Types::Strict::String
       end
     end

--- a/lib/persistence/relations/home_page_featured_items.rb
+++ b/lib/persistence/relations/home_page_featured_items.rb
@@ -5,7 +5,6 @@ module Persistence
         attribute :id, Types::Serial
         attribute :position, Types::Strict::Int
         attribute :title, Types::Strict::String
-        attribute :description, Types::Strict::String
         attribute :url, Types::Strict::String
         attribute :cover_image, Types::Strict::Hash
         attribute :highlight_color, Types::Strict::String

--- a/lib/persistence/relations/work_page_featured_items.rb
+++ b/lib/persistence/relations/work_page_featured_items.rb
@@ -6,7 +6,7 @@ module Persistence
         attribute :position, Types::Strict::Int
         attribute :title, Types::Strict::String
         attribute :url, Types::Strict::String
-        attribute :cover_image, Types::Strict::Hash
+        attribute :cover_image, Types::JSON
       end
     end
   end

--- a/lib/persistence/relations/work_page_featured_items.rb
+++ b/lib/persistence/relations/work_page_featured_items.rb
@@ -5,7 +5,6 @@ module Persistence
         attribute :id, Types::Serial
         attribute :position, Types::Strict::Int
         attribute :title, Types::Strict::String
-        attribute :description, Types::Strict::String
         attribute :url, Types::Strict::String
         attribute :cover_image, Types::Strict::Hash
       end


### PR DESCRIPTION
This PR removes the redundant `:description` attribute for home and work page featured items. 