### PR TITLE
[WIP] Add markdown support to titles, and highlight color attribute to work page featured items

### DIFF
--- a/apps/admin/lib/admin/pages/work/forms/edit_form.rb
+++ b/apps/admin/lib/admin/pages/work/forms/edit_form.rb
@@ -28,6 +28,14 @@ module Admin
                     filled: true
                   }
 
+                text_field :highlight_color,
+                  label: "Highlight Colour",
+                  placeholder: "Six-digit hexadecimal code, without the leading #",
+                  validation: {
+                    filled: true,
+                    format: "/^([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$/"
+                  }
+
                 upload_field :cover_image,
                   label: "Cover Image",
                   presign_url: "/admin/uploads/presign",

--- a/apps/admin/lib/admin/pages/work/validation/form.rb
+++ b/apps/admin/lib/admin/pages/work/validation/form.rb
@@ -14,6 +14,7 @@ module Admin
             required(:title).filled
             required(:url).filled
             required(:cover_image).filled(:hash?)
+            required(:highlight_color).filled
           end
         end
       end

--- a/apps/main/lib/main/entities/home_page_featured_item.rb
+++ b/apps/main/lib/main/entities/home_page_featured_item.rb
@@ -1,4 +1,5 @@
 require "types"
+require "redcarpet"
 
 module Main
   module Entities
@@ -14,9 +15,18 @@ module Main
         attache_url_for(cover_image["path"], "800") if cover_image
       end
 
+      def title_html
+        to_html(title)
+      end
+
       def attache_url_for(file_path, geometry)
         prefix, basename = File.split(file_path)
         [Berg::Container["config"].attache_downloads_base_url, "view", prefix, CGI.escape(geometry), CGI.escape(basename)].join('/')
+      end
+
+      def to_html(input)
+        markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, no_intra_emphasis: true)
+        markdown.render(input)
       end
     end
   end

--- a/apps/main/lib/main/entities/work_page_featured_item.rb
+++ b/apps/main/lib/main/entities/work_page_featured_item.rb
@@ -9,6 +9,7 @@ module Main
       attribute :title, Types::Strict::String
       attribute :url, Types::Strict::String
       attribute :cover_image, Types::Hash
+      attribute :highlight_color, Types::Strict::String
 
       def cover_image_url
         attache_url_for(cover_image["path"], "128") if cover_image

--- a/apps/main/lib/main/entities/work_page_featured_item.rb
+++ b/apps/main/lib/main/entities/work_page_featured_item.rb
@@ -1,4 +1,5 @@
 require "types"
+require "redcarpet"
 
 module Main
   module Entities
@@ -13,9 +14,18 @@ module Main
         attache_url_for(cover_image["path"], "128") if cover_image
       end
 
+      def title_html
+        to_html(title)
+      end
+
       def attache_url_for(file_path, geometry)
         prefix, basename = File.split(file_path)
         [Berg::Container["config"].attache_downloads_base_url, "view", prefix, CGI.escape(geometry), CGI.escape(basename)].join('/')
+      end
+
+      def to_html(input)
+        markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, no_intra_emphasis: true)
+        markdown.render(input)
       end
     end
   end

--- a/apps/main/web/templates/pages/home.html.slim
+++ b/apps/main/web/templates/pages/home.html.slim
@@ -21,4 +21,4 @@
       .project-feature-tile__overlay
         .project-feature-tile__overlay-gradient style="background-image: linear-gradient(to top, ##{featured_item.highlight_color} 5%, transparent 80%);"
         h1.project-feature-tile__label
-          = featured_item.title
+          == featured_item.title_html

--- a/apps/main/web/templates/pages/work.html.slim
+++ b/apps/main/web/templates/pages/work.html.slim
@@ -8,6 +8,7 @@ ul
   - featured_items.each do |featured_item|
     li
       == featured_item.title_html
+      p = featured_item.highlight_color
       p = featured_item.cover_image_url
 
 h2 Projects

--- a/apps/main/web/templates/pages/work.html.slim
+++ b/apps/main/web/templates/pages/work.html.slim
@@ -7,7 +7,7 @@ h1 Featured Items
 ul
   - featured_items.each do |featured_item|
     li
-      p = featured_item.title
+      == featured_item.title_html
       p = featured_item.cover_image_url
 
 h2 Projects

--- a/db/migrate/20160614020706_add_highlight_color_to_work_page_featured_items.rb
+++ b/db/migrate/20160614020706_add_highlight_color_to_work_page_featured_items.rb
@@ -1,0 +1,9 @@
+ROM::SQL.migration do
+  up do
+    add_column :work_page_featured_items, :highlight_color, String, null: false, default: ""
+  end
+
+  down do
+    drop_column :work_page_featured_items, :highlight_color
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -397,7 +397,8 @@ CREATE TABLE work_page_featured_items (
     "position" integer NOT NULL,
     title text NOT NULL,
     url text NOT NULL,
-    cover_image json DEFAULT '{}'::json NOT NULL
+    cover_image json DEFAULT '{}'::json NOT NULL,
+    highlight_color text DEFAULT ''::text NOT NULL
 );
 
 

--- a/lib/persistence/commands/update_work_page_featured_items.rb
+++ b/lib/persistence/commands/update_work_page_featured_items.rb
@@ -14,7 +14,8 @@ module Persistence
               position: position,
               title: item[:title],
               url: item[:url],
-              cover_image: item[:cover_image].to_json
+              cover_image: item[:cover_image].to_json,
+              highlight_color: item[:highlight_color]
             }
           end
 

--- a/lib/persistence/relations/work_page_featured_items.rb
+++ b/lib/persistence/relations/work_page_featured_items.rb
@@ -7,6 +7,7 @@ module Persistence
         attribute :title, Types::Strict::String
         attribute :url, Types::Strict::String
         attribute :cover_image, Types::JSON
+        attribute :highlight_color, Types::Strict::String
       end
     end
   end


### PR DESCRIPTION
This PR adds markdown support to titles for Home & Work Page Featured items:

![image](https://cloud.githubusercontent.com/assets/10018241/16029558/7d7f44b2-3224-11e6-9d22-b1a0fe09a20f.png)

This PR also adds a `highlight_color` attribute to Work Page Featured Items. This is used to specify the colour used for the gradient overlay atop the item's `cover_image` on the `/work` page