### PR TITLE
[WIP] Remove email attribute from People

### DIFF
--- a/apps/admin/lib/admin/entities/person.rb
+++ b/apps/admin/lib/admin/entities/person.rb
@@ -5,7 +5,6 @@ module Admin
     class Person < Dry::Types::Value
       attribute :id, Types::Strict::Int
       attribute :name, Types::Strict::String
-      attribute :email, Types::Strict::String
       attribute :bio, Types::Strict::String
       attribute :short_bio, Types::Strict::String
       attribute :avatar_image, Types::Coercible::Hash.optional

--- a/apps/admin/lib/admin/people/forms/form.rb
+++ b/apps/admin/lib/admin/people/forms/form.rb
@@ -12,12 +12,6 @@ module Admin
               validation: {
                 filled: true
               }
-            text_field :email,
-              label: "Email",
-              validation: {
-                filled: true,
-                format: EMAIL_VALIDATION_REGEX
-              }
           end
 
           group do

--- a/apps/admin/lib/admin/people/operations/update.rb
+++ b/apps/admin/lib/admin/people/operations/update.rb
@@ -15,7 +15,7 @@ module Admin
         def call(id, attributes)
           validation = Validation::Form.(prepare_attributes(attributes))
           if validation.success?
-            people.update(id, validation.to_h)
+            people.update_by_id(id, validation.to_h)
             Right(people[id])
           else
             Left(validation)

--- a/apps/admin/lib/admin/people/operations/update.rb
+++ b/apps/admin/lib/admin/people/operations/update.rb
@@ -26,7 +26,6 @@ module Admin
 
         def prepare_attributes(attributes)
           attributes.merge(
-            previous_email: attributes["email"],
             avatar_image: attributes["avatar_image"]
           )
         end

--- a/apps/admin/lib/admin/people/validation/form.rb
+++ b/apps/admin/lib/admin/people/validation/form.rb
@@ -7,33 +7,17 @@ module Admin
       Form = Berg::Validation.Form do
         configure do
           config.messages = :i18n
-
-          option :person_email_uniqueness_check, Admin::Container["admin.persistence.person_email_uniqueness_check"]
-
-          def email_unique?(value)
-            person_email_uniqueness_check.(value)
-          end
-
-          def not_eql?(input, value)
-            !input.eql?(value)
-          end
         end
 
-        required(:email).filled
         required(:bio).filled
         required(:short_bio).filled
         required(:name).filled
         required(:city).filled
 
         required(:job_title).maybe(:str?)
-        optional(:previous_email).maybe
         required(:avatar_image).maybe(:hash?)
         required(:twitter_handle).maybe(:str?)
         required(:website_url).maybe(:uri?)
-
-        rule(email: [:email, :previous_email]) do |email, previous_email|
-          email.not_eql?(previous_email).then(email.email_unique?)
-        end
       end
     end
   end

--- a/apps/admin/lib/admin/persistence/repositories/people.rb
+++ b/apps/admin/lib/admin/persistence/repositories/people.rb
@@ -12,10 +12,6 @@ module Admin
           people.by_id(id).as(Entities::Person).one
         end
 
-        def by_email(email)
-          people.by_email(email).as(Entities::Person).one
-        end
-
         def listing(per_page: 20, page: 1)
           people
             .per_page(per_page)

--- a/apps/admin/lib/admin/persistence/repositories/people.rb
+++ b/apps/admin/lib/admin/persistence/repositories/people.rb
@@ -6,10 +6,14 @@ module Admin
     module Repositories
       class People < Berg::Repository[:people]
         relations :people
-        commands :create, update: [:by_id]
+        commands :create, update: [:by_id, :by_name]
 
         def [](id)
           people.by_id(id).as(Entities::Person).one
+        end
+
+        def by_name(name)
+          people.by_name(name).as(Entities::Person).one
         end
 
         def listing(per_page: 20, page: 1)

--- a/apps/admin/web/templates/people/index.html.slim
+++ b/apps/admin/web/templates/people/index.html.slim
@@ -10,7 +10,6 @@ h1.h-1 People
           tr
             th ID
             th Name
-            th Email
         tbody
           - people.each do |person|
             tr id="person-#{person.id}"
@@ -18,6 +17,5 @@ h1.h-1 People
               td
                 a> href="/admin/people/#{person.id}/edit"
                   = person.name
-              td.f-mono = person.email
 p
   == paginator.pagination

--- a/apps/main/lib/main/entities/person.rb
+++ b/apps/main/lib/main/entities/person.rb
@@ -5,7 +5,6 @@ module Main
     class Person < Dry::Types::Value
       attribute :id, Types::Strict::Int
       attribute :name, Types::Strict::String
-      attribute :email, Types::Strict::String
       attribute :bio, Types::Strict::String
       attribute :short_bio, Types::Strict::String
       attribute :avatar_image, Types::Hash

--- a/db/migrate/20160615014457_remove_email_attribute_from_people.rb
+++ b/db/migrate/20160615014457_remove_email_attribute_from_people.rb
@@ -1,0 +1,9 @@
+ROM::SQL.migration do
+  up do
+    drop_column :people, :email
+  end
+
+  down do
+    add_column :people, :email, String, null: false
+  end
+end

--- a/db/sample_data.rb
+++ b/db/sample_data.rb
@@ -20,7 +20,7 @@ def create_user(attrs)
 end
 
 def create_person(attrs)
-  if !admin["admin.persistence.repositories.people"].by_email(attrs[:email])
+  if !admin["admin.persistence.repositories.people"][attrs[:id]]
     admin["admin.people.operations.create"].call(attrs).value
   end
 end
@@ -48,7 +48,6 @@ create_user(
 )
 
 create_person(
-  email: "person@icelab.com.au",
   name: "Icelab Person",
   bio: "An icelab person",
   short_bio: "An icelab person",
@@ -60,7 +59,7 @@ create_person(
 )
 
 admin["admin.users.operations.change_password"].(1, { password: "changeme" })
-author = admin["admin.persistence.repositories.people"].by_email("person@icelab.com.au")
+author = admin["admin.persistence.repositories.people"][1]
 
 20.times do |n|
   create_post(

--- a/db/sample_data.rb
+++ b/db/sample_data.rb
@@ -20,7 +20,7 @@ def create_user(attrs)
 end
 
 def create_person(attrs)
-  if !admin["admin.persistence.repositories.people"][attrs[:id]]
+  if !admin["admin.persistence.repositories.people"].by_name(attrs[:name])
     admin["admin.people.operations.create"].call(attrs).value
   end
 end
@@ -59,7 +59,7 @@ create_person(
 )
 
 admin["admin.users.operations.change_password"].(1, { password: "changeme" })
-author = admin["admin.persistence.repositories.people"][1]
+author = admin["admin.persistence.repositories.people"].by_name("Icelab Person")
 
 20.times do |n|
   create_post(

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -190,7 +190,6 @@ ALTER SEQUENCE office_contact_details_id_seq OWNED BY office_contact_details.id;
 CREATE TABLE people (
     id integer NOT NULL,
     twitter_handle text,
-    email text NOT NULL,
     bio text NOT NULL,
     website_url text,
     avatar_image json,

--- a/lib/persistence/relations/people.rb
+++ b/lib/persistence/relations/people.rb
@@ -20,6 +20,10 @@ module Persistence
         where(id: id)
       end
 
+      def by_name(name)
+        where(name: name)
+      end
+
       def for_about_page
         select
           .inner_join(

--- a/lib/persistence/relations/people.rb
+++ b/lib/persistence/relations/people.rb
@@ -4,7 +4,6 @@ module Persistence
       schema(:people) do
         attribute :id, Types::Serial
         attribute :name, Types::Strict::String
-        attribute :email, Types::Strict::String
         attribute :bio, Types::Strict::String
         attribute :short_bio, Types::Strict::String
         attribute :twitter_handle, Types::Strict::String.optional
@@ -19,10 +18,6 @@ module Persistence
 
       def by_id(id)
         where(id: id)
-      end
-
-      def by_email(email)
-        where(email: email)
       end
 
       def for_about_page

--- a/spec/admin/features/people/create_spec.rb
+++ b/spec/admin/features/people/create_spec.rb
@@ -13,7 +13,6 @@ RSpec.feature "Admin / People / Create", js: true do
     find("a", text: "Add a person").trigger("click")
 
     find("#name").set("John Doe")
-    find("#email").set("john.doe@icelab.com.au")
     find("#bio").set("A simple bio")
     find("#short_bio").set("A Short bio")
     find("#city").set("Melbourne")

--- a/spec/admin/features/people/edit_spec.rb
+++ b/spec/admin/features/people/edit_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Admin / People / Edit", js: true do
   include_context "admin people"
 
   before(:each) do
-    @person = create_person("John Doe", "john.doe@example.com", "A bio for John Doe")
+    @person = create_person("John Doe", "A bio for John Doe")
   end
 
   background do

--- a/spec/admin/shared/app/admin_people.rb
+++ b/spec/admin/shared/app/admin_people.rb
@@ -1,8 +1,7 @@
 RSpec.shared_context "admin people" do
-  def create_person(name, email, bio, attrs = {})
+  def create_person(name, bio, attrs = {})
     Admin::Container["admin.people.operations.create"].({
       "name" => name,
-      "email" => email,
       "bio" => bio,
       "short_bio" => bio,
       "active" => true,
@@ -14,5 +13,5 @@ RSpec.shared_context "admin people" do
     }.merge(attrs)).value
   end
 
-  let!(:sample_person) { create_person("Jane", "person@example.com", "bio") }
+  let!(:sample_person) { create_person("Jane", "bio") }
 end

--- a/spec/admin/shared/app/admin_posts.rb
+++ b/spec/admin/shared/app/admin_posts.rb
@@ -1,17 +1,17 @@
 require "babosa"
 
 RSpec.shared_context "admin posts" do
-  def create_post(title, person_id, attrs = {})
+  def create_post(title, attrs = {})
     # TODO: we need fixtures
     Admin::Container["admin.posts.operations.create"].({
       "title" => title,
       "teaser" => "A teaser for this sample post",
       "body" => "Some sample content for this post",
-      "person_id" => person_id,
+      "person_id" => Admin::Container["admin.persistence.repositories.people"].by_name("Jane").id,
       "slug" => title.to_slug.normalize.to_s,
       "cover_image" => nil
     }.merge(attrs)).value
   end
 
-  let!(:sample_post) { create_post("A Sample Post", 1) }
+  let!(:sample_post) { create_post("A Sample Post") }
 end

--- a/spec/admin/shared/app/admin_posts.rb
+++ b/spec/admin/shared/app/admin_posts.rb
@@ -1,17 +1,17 @@
 require "babosa"
 
 RSpec.shared_context "admin posts" do
-  def create_post(title, attrs = {})
+  def create_post(title, person_id, attrs = {})
     # TODO: we need fixtures
     Admin::Container["admin.posts.operations.create"].({
       "title" => title,
       "teaser" => "A teaser for this sample post",
       "body" => "Some sample content for this post",
-      "person_id" => Admin::Container["admin.persistence.repositories.people"][1],
+      "person_id" => person_id,
       "slug" => title.to_slug.normalize.to_s,
       "cover_image" => nil
     }.merge(attrs)).value
   end
 
-  let!(:sample_post) { create_post("A Sample Post") }
+  let!(:sample_post) { create_post("A Sample Post", 1) }
 end

--- a/spec/admin/shared/app/admin_posts.rb
+++ b/spec/admin/shared/app/admin_posts.rb
@@ -7,7 +7,7 @@ RSpec.shared_context "admin posts" do
       "title" => title,
       "teaser" => "A teaser for this sample post",
       "body" => "Some sample content for this post",
-      "person_id" => Admin::Container["admin.persistence.repositories.people"].by_email("person@example.com").id,
+      "person_id" => Admin::Container["admin.persistence.repositories.people"][1],
       "slug" => title.to_slug.normalize.to_s,
       "cover_image" => nil
     }.merge(attrs)).value


### PR DESCRIPTION
This PR removes the `:email` attribute from People as this attribute is not being used in the admin app or displayed anywhere in the public app. 