### PR TITLE
Add `latitude` and `longitude` fields to the contact locations.

### DIFF
--- a/apps/admin/lib/admin/entities/office_contact_detail.rb
+++ b/apps/admin/lib/admin/entities/office_contact_detail.rb
@@ -7,6 +7,8 @@ module Admin
       attribute :name, Types::Strict::String
       attribute :address, Types::Strict::String
       attribute :phone_number, Types::Strict::String
+      attribute :latitude, Types::Strict::String
+      attribute :longitude, Types::Strict::String
     end
   end
 end

--- a/apps/admin/lib/admin/pages/contact/forms/edit_form.rb
+++ b/apps/admin/lib/admin/pages/contact/forms/edit_form.rb
@@ -25,6 +25,16 @@ module Admin
                 validation: {
                   filled: true
                 }
+              text_field :latitude,
+                label: "Latitude",
+                validation: {
+                  filled: true
+                }
+              text_field :longitude,
+                label: "Longitude",
+                validation: {
+                  filled: true
+                }
             end
           end
         end

--- a/apps/admin/lib/admin/pages/contact/validation/form.rb
+++ b/apps/admin/lib/admin/pages/contact/validation/form.rb
@@ -15,6 +15,8 @@ module Admin
               required(:name).filled
               required(:address).filled
               required(:phone_number).filled
+              required(:latitude).filled
+              required(:longitude).filled
             end
           end
         end

--- a/apps/admin/lib/admin/views/pages/contact/edit.rb
+++ b/apps/admin/lib/admin/views/pages/contact/edit.rb
@@ -41,7 +41,9 @@ module Admin
                 {
                   name: location_details[:name],
                   address: location_details[:address],
-                  phone_number: location_details[:phone_number]
+                  phone_number: location_details[:phone_number],
+                  latitude: location_details[:latitude],
+                  longitude: location_details[:longitude]
                 }
               }
             }

--- a/apps/main/lib/main/entities/office_contact_detail.rb
+++ b/apps/main/lib/main/entities/office_contact_detail.rb
@@ -8,6 +8,8 @@ module Main
       attribute :name, Types::Strict::String
       attribute :address, Types::Strict::String
       attribute :phone_number, Types::Strict::String
+      attribute :latitude, Types::Strict::String
+      attribute :longitude, Types::Strict::String
 
       def name_html
         to_html(name)

--- a/db/migrate/20160620013314_add_coordinates_to_office_contact_details.rb
+++ b/db/migrate/20160620013314_add_coordinates_to_office_contact_details.rb
@@ -1,0 +1,11 @@
+ROM::SQL.migration do
+  up do
+    add_column :office_contact_details, :latitude, String, null: false, default: ""
+    add_column :office_contact_details, :longitude, String, null: false, default: ""
+  end
+
+  down do
+    drop_column :office_contact_details, :latitude
+    drop_column :office_contact_details, :longitude
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -161,8 +161,6 @@ CREATE TABLE office_contact_details (
     name text NOT NULL,
     address text NOT NULL,
     phone_number text NOT NULL
-    latitude text NOT NULL
-    longitude text NOT NULL
 );
 
 
@@ -639,4 +637,3 @@ CREATE TRIGGER set_updated_at_on_users BEFORE UPDATE ON users FOR EACH ROW EXECU
 --
 -- PostgreSQL database dump complete
 --
-

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -161,6 +161,8 @@ CREATE TABLE office_contact_details (
     name text NOT NULL,
     address text NOT NULL,
     phone_number text NOT NULL
+    latitude text NOT NULL
+    longitude text NOT NULL
 );
 
 

--- a/lib/persistence/commands/update_office_contact_details.rb
+++ b/lib/persistence/commands/update_office_contact_details.rb
@@ -14,7 +14,9 @@ module Persistence
               position: position,
               name: location_details[:name],
               phone_number: location_details[:phone_number],
-              address: location_details[:address]
+              address: location_details[:address],
+              latitude: location_details[:latitude],
+              longitude: location_details[:longitude]
             }
           end
 

--- a/lib/persistence/relations/office_contact_details.rb
+++ b/lib/persistence/relations/office_contact_details.rb
@@ -7,6 +7,8 @@ module Persistence
         attribute :name, Types::Strict::String
         attribute :address, Types::Strict::String
         attribute :phone_number, Types::Strict::String
+        attribute :latitude, Types::Strict::String
+        attribute :longitude, Types::Strict::String
       end
 
       def by_position

--- a/spec/admin/features/pages/contact/edit_spec.rb
+++ b/spec/admin/features/pages/contact/edit_spec.rb
@@ -15,6 +15,8 @@ RSpec.feature "Admin / Pages / Contact / Edit", js: true do
     find("#name").set("Melbourne")
     find("#phone_number").set("03 9123 4567")
     find("#address").set("123 Fake Street")
+    find("#latitude").set("-35.279795")
+    find("#longitude").set("149.126166")
 
     find("button", text: "Save changes").trigger("click")
 
@@ -33,6 +35,8 @@ RSpec.feature "Admin / Pages / Contact / Edit", js: true do
 
     find("#name").set("Melbourne")
     find("#phone_number").set("03 9123 4567")
+    find("#latitude").set("-35.279795")
+    find("#longitude").set("149.126166")
 
     find("button", text: "Save changes").trigger("click")
 


### PR DESCRIPTION
Hey @dylanwolff,

I'd like to add `latitude` and `longitude` fields to the contact locations so that we can set a nice looking map pin on the contact page. I've taken a stab at doing this — would you mind giving it a developer look over? I might need a hand creating a migration too.

Cheers,
Andy