### PR TITLE
Remove `tags` attribute from Projects

### DIFF
--- a/apps/admin/lib/admin/entities/project.rb
+++ b/apps/admin/lib/admin/entities/project.rb
@@ -10,7 +10,6 @@ module Admin
       attribute :url, Types::Strict::String
       attribute :intro, Types::Strict::String
       attribute :body, Types::Strict::String.optional
-      attribute :tags, Types::Strict::String
       attribute :slug, Types::Strict::String
       attribute :status, Types::ProjectStatus
       attribute :published_at, Types::Strict::Time.optional

--- a/apps/admin/lib/admin/projects/forms/create_form.rb
+++ b/apps/admin/lib/admin/projects/forms/create_form.rb
@@ -35,11 +35,6 @@ module Admin
             validation: {
               filled: true
             }
-          text_field :tags,
-            label: "Tags",
-            validation: {
-              filled: true
-            }
 
           upload_field :cover_image,
             label: "Cover Image",

--- a/apps/admin/lib/admin/projects/forms/edit_form.rb
+++ b/apps/admin/lib/admin/projects/forms/edit_form.rb
@@ -40,11 +40,6 @@ module Admin
             validation: {
               filled: true
             }
-          text_field :tags,
-            label: "Tags",
-            validation: {
-              filled: true
-            }
 
           upload_field :cover_image,
             label: "Cover Image",

--- a/apps/admin/lib/admin/projects/validation/form.rb
+++ b/apps/admin/lib/admin/projects/validation/form.rb
@@ -25,7 +25,6 @@ module Admin
         required(:url).filled
         required(:intro).filled
         required(:body).maybe
-        required(:tags).filled
         required(:case_study).filled(:bool?)
 
         # Required in only the edit form

--- a/apps/main/lib/main/entities/project.rb
+++ b/apps/main/lib/main/entities/project.rb
@@ -9,7 +9,6 @@ module Main
       attribute :url, Types::Strict::String
       attribute :intro, Types::Strict::String
       attribute :body, Types::Strict::String
-      attribute :tags, Types::Strict::String
       attribute :slug, Types::Strict::String
       attribute :status, Types::ProjectStatus
       attribute :published_at, Types::Strict::Time

--- a/db/migrate/20160620110728_remove_tags_from_projects.rb
+++ b/db/migrate/20160620110728_remove_tags_from_projects.rb
@@ -1,0 +1,9 @@
+ROM::SQL.migration do
+  up do
+    drop_column :projects, :tags
+  end
+
+  down do
+    add_column :projects, :tags, String, null: false
+  end
+end

--- a/db/sample_data.rb
+++ b/db/sample_data.rb
@@ -81,7 +81,6 @@ end
     url: Faker::Internet.url,
     intro: Faker::Hipster.sentence,
     body: Faker::Hipster.paragraph,
-    tags: Faker::Hipster.word,
     status: "draft",
     case_study: false,
     cover_image: nil

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -274,7 +274,6 @@ CREATE TABLE projects (
     url text NOT NULL,
     intro text NOT NULL,
     body text,
-    tags text NOT NULL,
     slug text NOT NULL,
     status text DEFAULT 'draft'::text,
     published_at timestamp without time zone,

--- a/lib/persistence/relations/projects.rb
+++ b/lib/persistence/relations/projects.rb
@@ -8,7 +8,6 @@ module Persistence
         attribute :url, Types::Strict::String
         attribute :intro, Types::Strict::String
         attribute :body, Types::String.optional
-        attribute :tags, Types::Strict::String
         attribute :slug, Types::Strict::String
         attribute :status, Types::Strict::String
         attribute :published_at, Types::Time.optional

--- a/spec/admin/features/projects/create_spec.rb
+++ b/spec/admin/features/projects/create_spec.rb
@@ -17,7 +17,6 @@ RSpec.feature "Admin / Projects / Create", js: true do
     find("#url").set("http://example.com")
     find("#intro").set("Intro text for this example project")
     find("#body").set("Body content for this example project")
-    find("#tags").set("examplepost")
 
     find("button", text: "Create project").trigger("click")
 
@@ -36,7 +35,6 @@ RSpec.feature "Admin / Projects / Create", js: true do
     find("#url").set("http://example.com")
     find("#intro").set("Intro text for this example project")
     find("#body").set("Body content for this example project")
-    find("#tags").set("examplepost")
 
     find("button", text: "Create project").trigger("click")
 

--- a/spec/admin/shared/app/admin_projects.rb
+++ b/spec/admin/shared/app/admin_projects.rb
@@ -8,7 +8,6 @@ RSpec.shared_context "admin projects" do
       "url" => "http://example.com",
       "intro" => "Intro text for this example project",
       "body" => "Body content for this example project",
-      "tags" => "examplepost",
       "slug" => title.to_slug.normalize.to_s,
       "case_study" => false,
       "cover_image" => nil,

--- a/spec/main/features/pages_spec.rb
+++ b/spec/main/features/pages_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Main / Pages" do
   scenario "Visiting the Home page" do
     visit "/"
     expect(page.status_code).to eql 200
-    expect(page).to have_title "Home — Icelab"
+    expect(page).to have_title "Icelab — an Australian design studio"
   end
 
   scenario "Visiting the Work page" do

--- a/spec/main/features/posts/index_spec.rb
+++ b/spec/main/features/posts/index_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "Main / Posts / Index", js: false do
   scenario "I see the 404 page if I try view a category that doesn't exist" do
     visit "/notes/category/rb"
 
-    expect(page).to have_content "Oops! We couldn’t find this page."
+    expect(page).to have_content "Oops! We couldn’t find this page"
   end
 
 end

--- a/spec/main/features/posts/show_spec.rb
+++ b/spec/main/features/posts/show_spec.rb
@@ -27,6 +27,6 @@ RSpec.feature "Main / Posts / Show", js: false do
     visit "/notes/secret-post"
 
     expect(page.current_path).to eq "/notes/secret-post"
-    expect(page).to have_content "Oops! We couldn’t find this page."
+    expect(page).to have_content "Oops! We couldn’t find this page"
   end
 end

--- a/spec/main/features/projects/show_spec.rb
+++ b/spec/main/features/projects/show_spec.rb
@@ -23,6 +23,6 @@ RSpec.feature "Main / Projects / Show", js: false do
     visit "/work/secret-project"
 
     expect(page.current_path).to eq "/work/secret-project"
-    expect(page).to have_content "Oops! We couldn’t find this page."
+    expect(page).to have_content "Oops! We couldn’t find this page"
   end
 end


### PR DESCRIPTION
Now that I'm looking to to start migrating over existing Projects, it's occurred to me that the approach here for tagging/categorising Projects isn't right, and probably needs to be more like the approach @dNitza used for Posts.

I'd like to start inputting content tomorrow and currently the form validation requires input for `tags`. I figure that rather than filling this with redundant data it makes more sense to remove this attribute entirely and add a more robust implementation to the wishlist for v2.

Interested in your opinion on my thinking @timriley.