### PR TITLE
Make URL an optional attribute for Projects

### DIFF
--- a/apps/admin/lib/admin/entities/project.rb
+++ b/apps/admin/lib/admin/entities/project.rb
@@ -7,7 +7,7 @@ module Admin
       attribute :id, Types::Strict::Int
       attribute :title, Types::Strict::String
       attribute :client, Types::Strict::String
-      attribute :url, Types::Strict::String
+      attribute :url, Types::Strict::String.optional
       attribute :intro, Types::Strict::String
       attribute :body, Types::Strict::String.optional
       attribute :slug, Types::Strict::String

--- a/apps/admin/lib/admin/projects/forms/create_form.rb
+++ b/apps/admin/lib/admin/projects/forms/create_form.rb
@@ -21,10 +21,7 @@ module Admin
               filled: true
             }
           text_field :url,
-            label: "URL",
-            validation: {
-              filled: true
-            }
+            label: "URL"
           text_area :intro,
             label: "Introduction",
             validation: {

--- a/apps/admin/lib/admin/projects/forms/edit_form.rb
+++ b/apps/admin/lib/admin/projects/forms/edit_form.rb
@@ -21,10 +21,7 @@ module Admin
               filled: true
             }
           text_field :url,
-            label: "URL",
-            validation: {
-              filled: true
-            }
+            label: "URL"
           text_area :intro,
             label: "Introduction",
             validation: {

--- a/apps/admin/lib/admin/projects/validation/form.rb
+++ b/apps/admin/lib/admin/projects/validation/form.rb
@@ -19,22 +19,21 @@ module Admin
           end
         end
 
-        # Required in both the new and edit forms
         required(:title).filled
         required(:client).filled
-        required(:url).maybe
         required(:intro).filled
-        required(:body).maybe
         required(:case_study).filled(:bool?)
+
+        required(:url).maybe(:uri?)
+        required(:body).maybe(:str?)
+        required(:cover_image).maybe(:hash?)
+        required(:assets).each(:hash?)
 
         # Required in only the edit form
         optional(:slug).filled
         optional(:previous_slug).filled
         optional(:status).filled(included_in?: Types::ProjectStatus.values)
         optional(:published_at).maybe(:time?)
-
-        required(:cover_image).maybe(:hash?)
-        required(:assets).each(:hash?)
 
         rule(body: [:body, :case_study]) do |body, case_study|
           case_study.eql?(true).then(body.filled?)

--- a/apps/admin/lib/admin/projects/validation/form.rb
+++ b/apps/admin/lib/admin/projects/validation/form.rb
@@ -22,7 +22,7 @@ module Admin
         # Required in both the new and edit forms
         required(:title).filled
         required(:client).filled
-        required(:url).filled
+        required(:url).maybe
         required(:intro).filled
         required(:body).maybe
         required(:case_study).filled(:bool?)

--- a/apps/main/lib/main/entities/project.rb
+++ b/apps/main/lib/main/entities/project.rb
@@ -6,7 +6,7 @@ module Main
       attribute :id, Types::Strict::Int
       attribute :title, Types::Strict::String
       attribute :client, Types::Strict::String
-      attribute :url, Types::Strict::String
+      attribute :url, Types::Strict::String.optional
       attribute :intro, Types::Strict::String
       attribute :body, Types::Strict::String
       attribute :slug, Types::Strict::String

--- a/db/migrate/20160620231550_change_projects_url_null.rb
+++ b/db/migrate/20160620231550_change_projects_url_null.rb
@@ -1,0 +1,7 @@
+ROM::SQL.migration do
+  change do
+    alter_table(:projects) do
+      set_column_allow_null :url
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -271,7 +271,7 @@ CREATE TABLE projects (
     id integer NOT NULL,
     title text NOT NULL,
     client text NOT NULL,
-    url text NOT NULL,
+    url text,
     intro text NOT NULL,
     body text,
     slug text NOT NULL,

--- a/lib/persistence/relations/projects.rb
+++ b/lib/persistence/relations/projects.rb
@@ -5,7 +5,7 @@ module Persistence
         attribute :id, Types::Serial
         attribute :title, Types::Strict::String
         attribute :client, Types::Strict::String
-        attribute :url, Types::Strict::String
+        attribute :url, Types::Strict::String.optional
         attribute :intro, Types::Strict::String
         attribute :body, Types::String.optional
         attribute :slug, Types::Strict::String


### PR DESCRIPTION
This PR makes `url` an optional attribute for Projects, which accommodates the many existing Projects to be migrated from the current site that don't have a URL set. 