### PR TITLE
Change `deleted` status type for Posts and Projects to `hidden`

### DIFF
--- a/apps/admin/lib/admin/decorators/post.rb
+++ b/apps/admin/lib/admin/decorators/post.rb
@@ -13,7 +13,7 @@ module Admin
         case status
         when "draft"
           "ghost"
-        when "deleted"
+        when "hidden"
           "warning"
         when "published"
           "success"

--- a/apps/admin/lib/admin/decorators/project.rb
+++ b/apps/admin/lib/admin/decorators/project.rb
@@ -1,11 +1,15 @@
 module Admin
   module Decorators
     class Project < SimpleDelegator
+      def published_date
+        published_at.strftime("%e %b %Y %H:%M:%S%p")
+      end
+
       def status_class
         case status
         when "draft"
           "ghost"
-        when "deleted"
+        when "hidden"
           "warning"
         when "published"
           "success"
@@ -14,10 +18,6 @@ module Admin
 
       def status_label
         status.capitalize
-      end
-
-      def published_date
-        published_at.strftime("%e %b %Y %H:%M:%S%p")
       end
     end
   end

--- a/apps/admin/lib/admin/entities/post.rb
+++ b/apps/admin/lib/admin/entities/post.rb
@@ -18,10 +18,6 @@ module Admin
       attribute :color, Types::PostHighlightColor
       attribute :assets, Types::Coercible::Array.member(Admin::Entities::Asset).optional
 
-      def deleted?
-        status == "deleted"
-      end
-
       def published?
         status == "published"
       end

--- a/apps/admin/lib/admin/entities/project.rb
+++ b/apps/admin/lib/admin/entities/project.rb
@@ -17,10 +17,6 @@ module Admin
       attribute :cover_image, Types::Coercible::Hash.optional
       attribute :assets, Types::Coercible::Array.member(Admin::Entities::Asset).optional
 
-      def deleted?
-        status == "deleted"
-      end
-
       def published?
         status == "published"
       end

--- a/apps/admin/lib/admin/posts/forms/edit_form.rb
+++ b/apps/admin/lib/admin/posts/forms/edit_form.rb
@@ -46,10 +46,6 @@ module Admin
                 filled: true
               }
 
-            group do
-              select_box :status, label: "Status", options: dep(:status_list)
-              date_time_field :published_at, label: "Published at"
-            end
             multi_selection_field :post_categories,
               label: "Categories",
               selector_label: "Choose categories",
@@ -64,6 +60,11 @@ module Admin
               label: "Additional Images",
               hint: "Images to display inline",
               presign_url: "/admin/uploads/presign"
+          end
+
+          group do
+            select_box :status, label: "Status", options: dep(:status_list)
+            date_time_field :published_at, label: "Published at"
           end
         end
 

--- a/apps/admin/lib/admin/projects/forms/edit_form.rb
+++ b/apps/admin/lib/admin/projects/forms/edit_form.rb
@@ -49,7 +49,7 @@ module Admin
 
           select_box :status,
             label: "Status", options: [
-              ["draft", "Draft"], ["published", "Published"], ["deleted", "Deleted"]
+              ["draft", "Draft"], ["published", "Published"], ["hidden", "Hidden"]
             ]
           date_time_field :published_at, label: "Published at"
           check_box :case_study, label: "Case Study", question_text: "Mark as a Case Study?"

--- a/apps/admin/lib/admin/projects/forms/edit_form.rb
+++ b/apps/admin/lib/admin/projects/forms/edit_form.rb
@@ -47,12 +47,16 @@ module Admin
             hint: "Images to display inline",
             presign_url: "/admin/uploads/presign"
 
-          select_box :status,
-            label: "Status", options: [
-              ["draft", "Draft"], ["published", "Published"], ["hidden", "Hidden"]
-            ]
-          date_time_field :published_at, label: "Published at"
+          group do
+            select_box :status, label: "Status", options: dep(:status_list)
+            date_time_field :published_at, label: "Published at"
+          end
+
           check_box :case_study, label: "Case Study", question_text: "Mark as a Case Study?"
+        end
+
+        def status_list
+          Types::ProjectStatus.values.map { |value| [value, value.capitalize] }
         end
       end
     end

--- a/lib/types.rb
+++ b/lib/types.rb
@@ -5,7 +5,7 @@ module Types
 
   PostHighlightColor = Types::Strict::String.enum("red", "green", "blue", "grey")
   PostStatus = Types::Strict::String.default("draft").enum("draft", "published", "deleted")
-  ProjectStatus = Types::Strict::String.default("draft").enum("draft", "published", "deleted")
+  ProjectStatus = Types::Strict::String.default("draft").enum("draft", "published", "hidden")
 end
 
 require "rom_sql_types"

--- a/lib/types.rb
+++ b/lib/types.rb
@@ -4,7 +4,7 @@ module Types
   include Dry::Types.module
 
   PostHighlightColor = Types::Strict::String.enum("red", "green", "blue", "grey")
-  PostStatus = Types::Strict::String.default("draft").enum("draft", "published", "deleted")
+  PostStatus = Types::Strict::String.default("draft").enum("draft", "published", "hidden")
   ProjectStatus = Types::Strict::String.default("draft").enum("draft", "published", "hidden")
 end
 


### PR DESCRIPTION
This better describes the status of a record we don't want visible on the public site, given we're not actually deleting anything. 