### PR TITLE
Adds color field to projects

### DIFF
--- a/apps/admin/component/container/persistence.rb
+++ b/apps/admin/component/container/persistence.rb
@@ -37,6 +37,13 @@ Admin::Container.namespace "admin.persistence" do |container|
     )
   end
 
+  container.register "project_color_picker" do
+    Admin::Persistence::PostColorPicker.new(
+      Types::PostHighlightColor,
+      container["admin.persistence.repositories.projects"].method(:recent_colors)
+    )
+  end
+
   container.register "project_slug_uniqueness_check" do
     Admin::Persistence::UniquenessCheck.new(
       container["core.persistence.rom"].relation(:projects),

--- a/apps/admin/lib/admin/entities/project.rb
+++ b/apps/admin/lib/admin/entities/project.rb
@@ -15,6 +15,7 @@ module Admin
       attribute :published_at, Types::Strict::Time.optional
       attribute :case_study, Types::Strict::Bool
       attribute :cover_image, Types::Coercible::Hash.optional
+      attribute :color, Types::PostHighlightColor
       attribute :assets, Types::Coercible::Array.member(Admin::Entities::Asset).optional
 
       def published?

--- a/apps/admin/lib/admin/persistence/repositories/projects.rb
+++ b/apps/admin/lib/admin/persistence/repositories/projects.rb
@@ -29,6 +29,14 @@ module Admin
             .order(Sequel.desc(:published_at))
             .as(Entities::Project)
         end
+
+        def recent_colors
+          projects
+            .select(:color)
+            .order(Sequel.desc(:created_at))
+            .limit((Types::PostHighlightColor.values.count / 2).floor)
+            .map{ |p| p[:color] }
+        end
       end
     end
   end

--- a/apps/admin/lib/admin/projects/operations/create.rb
+++ b/apps/admin/lib/admin/projects/operations/create.rb
@@ -9,7 +9,8 @@ module Admin
       class Create
         include Admin::Import(
           "admin.persistence.repositories.projects",
-          "admin.slugify"
+          "admin.slugify",
+          "admin.persistence.project_color_picker",
         )
 
         include Dry::ResultMatcher.for(:call)
@@ -29,7 +30,8 @@ module Admin
 
         def prepare_attributes(attributes)
           attributes.merge(
-            slug: slugify.(attributes[:title], projects.method(:slug_exists?))
+            slug: slugify.(attributes[:title], projects.method(:slug_exists?)),
+            color: project_color_picker.()
           )
         end
       end

--- a/apps/main/lib/main/entities/project.rb
+++ b/apps/main/lib/main/entities/project.rb
@@ -14,6 +14,7 @@ module Main
       attribute :published_at, Types::Strict::Time
       attribute :case_study, Types::Strict::Bool
       attribute :cover_image, Types::Hash
+      attribute :color, Types::PostHighlightColor
       attribute :assets, Types::Hash
     end
   end

--- a/apps/main/web/templates/pages/work.html.slim
+++ b/apps/main/web/templates/pages/work.html.slim
@@ -49,7 +49,8 @@
 
 .project-tiles.grid.grid--full.mx-auto
   - projects.each do |project|
-    a.project-tile.project-tile--with-text href="/work/#{project.slug}" class=("project-tile--with-background-image" if project.cover_image_url)
+    - background_image_classname = (project.cover_image_url ? 'project-tile--with-background-image' : '')
+    a.project-tile.project-tile--with-text href="/work/#{project.slug}" class=["project-tile--#{project.color}", background_image_classname]
       - if project.cover_image_url
         .project-tile__inner style="background-image:url('#{project.cover_image_url}');"
           .project-tile__text-container

--- a/apps/main/web/templates/projects/show.html.slim
+++ b/apps/main/web/templates/projects/show.html.slim
@@ -4,7 +4,7 @@
   meta property="og:description" content=project.body.gsub(/<\/?[^>]*>/,"").gsub(/^(.{400,}?).*$/m,'\1...')
 
 .project
-  .pulled-heading.pulled-heading--serif.pulled-heading--mid.pulled-heading--color-green.pulled-heading--border-red.mx-auto
+  .pulled-heading.pulled-heading--serif.pulled-heading--mid.pulled-heading--border-red.mx-auto class="pulled-heading--color-#{project.color}"
     h3.pulled-heading__heading
       span == project.title_html
   .project__body.grid.grid--mid.mx-auto

--- a/db/migrate/20160621074811_add_color_to_projects.rb
+++ b/db/migrate/20160621074811_add_color_to_projects.rb
@@ -1,0 +1,9 @@
+ROM::SQL.migration do
+  up do
+    add_column :projects, :color, String, null: false, default: ""
+  end
+
+  down do
+    drop_column :projects, :color
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,16 +2,12 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.2
--- Dumped by pg_dump version 9.5.2
-
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
-SET row_security = off;
 
 --
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
@@ -48,7 +44,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: about_page_people; Type: TABLE; Schema: public; Owner: -
+-- Name: about_page_people; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE about_page_people (
@@ -58,7 +54,7 @@ CREATE TABLE about_page_people (
 
 
 --
--- Name: categories; Type: TABLE; Schema: public; Owner: -
+-- Name: categories; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE categories (
@@ -88,7 +84,7 @@ ALTER SEQUENCE categories_id_seq OWNED BY categories.id;
 
 
 --
--- Name: categorisations; Type: TABLE; Schema: public; Owner: -
+-- Name: categorisations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE categorisations (
@@ -118,7 +114,7 @@ ALTER SEQUENCE categorisations_id_seq OWNED BY categorisations.id;
 
 
 --
--- Name: home_page_featured_items; Type: TABLE; Schema: public; Owner: -
+-- Name: home_page_featured_items; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE home_page_featured_items (
@@ -152,7 +148,7 @@ ALTER SEQUENCE home_page_featured_items_id_seq OWNED BY home_page_featured_items
 
 
 --
--- Name: office_contact_details; Type: TABLE; Schema: public; Owner: -
+-- Name: office_contact_details; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE office_contact_details (
@@ -186,7 +182,7 @@ ALTER SEQUENCE office_contact_details_id_seq OWNED BY office_contact_details.id;
 
 
 --
--- Name: people; Type: TABLE; Schema: public; Owner: -
+-- Name: people; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE people (
@@ -224,7 +220,7 @@ ALTER SEQUENCE people_id_seq OWNED BY people.id;
 
 
 --
--- Name: posts; Type: TABLE; Schema: public; Owner: -
+-- Name: posts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE posts (
@@ -264,7 +260,7 @@ ALTER SEQUENCE posts_id_seq OWNED BY posts.id;
 
 
 --
--- Name: projects; Type: TABLE; Schema: public; Owner: -
+-- Name: projects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE projects (
@@ -281,7 +277,8 @@ CREATE TABLE projects (
     updated_at timestamp without time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
     case_study boolean DEFAULT false NOT NULL,
     cover_image json,
-    assets json
+    assets json,
+    color text DEFAULT ''::text NOT NULL
 );
 
 
@@ -305,7 +302,7 @@ ALTER SEQUENCE projects_id_seq OWNED BY projects.id;
 
 
 --
--- Name: que_jobs; Type: TABLE; Schema: public; Owner: -
+-- Name: que_jobs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE que_jobs (
@@ -347,7 +344,7 @@ ALTER SEQUENCE que_jobs_job_id_seq OWNED BY que_jobs.job_id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE schema_migrations (
@@ -356,7 +353,7 @@ CREATE TABLE schema_migrations (
 
 
 --
--- Name: users; Type: TABLE; Schema: public; Owner: -
+-- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE users (
@@ -392,7 +389,7 @@ ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
 --
--- Name: work_page_featured_items; Type: TABLE; Schema: public; Owner: -
+-- Name: work_page_featured_items; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE TABLE work_page_featured_items (
@@ -496,7 +493,7 @@ ALTER TABLE ONLY work_page_featured_items ALTER COLUMN id SET DEFAULT nextval('w
 
 
 --
--- Name: categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY categories
@@ -504,7 +501,7 @@ ALTER TABLE ONLY categories
 
 
 --
--- Name: categorisations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: categorisations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY categorisations
@@ -512,7 +509,7 @@ ALTER TABLE ONLY categorisations
 
 
 --
--- Name: home_page_featured_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: home_page_featured_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY home_page_featured_items
@@ -520,7 +517,7 @@ ALTER TABLE ONLY home_page_featured_items
 
 
 --
--- Name: office_contact_details_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: office_contact_details_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY office_contact_details
@@ -528,7 +525,7 @@ ALTER TABLE ONLY office_contact_details
 
 
 --
--- Name: people_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: people_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY people
@@ -536,7 +533,7 @@ ALTER TABLE ONLY people
 
 
 --
--- Name: posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY posts
@@ -544,7 +541,7 @@ ALTER TABLE ONLY posts
 
 
 --
--- Name: posts_slug_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: posts_slug_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY posts
@@ -552,7 +549,7 @@ ALTER TABLE ONLY posts
 
 
 --
--- Name: projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY projects
@@ -560,7 +557,7 @@ ALTER TABLE ONLY projects
 
 
 --
--- Name: projects_slug_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: projects_slug_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY projects
@@ -568,7 +565,7 @@ ALTER TABLE ONLY projects
 
 
 --
--- Name: que_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: que_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY que_jobs
@@ -576,7 +573,7 @@ ALTER TABLE ONLY que_jobs
 
 
 --
--- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY schema_migrations
@@ -584,7 +581,7 @@ ALTER TABLE ONLY schema_migrations
 
 
 --
--- Name: users_email_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: users_email_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY users
@@ -592,7 +589,7 @@ ALTER TABLE ONLY users
 
 
 --
--- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY users
@@ -600,7 +597,7 @@ ALTER TABLE ONLY users
 
 
 --
--- Name: work_page_featured_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: work_page_featured_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY work_page_featured_items

--- a/lib/persistence/relations/projects.rb
+++ b/lib/persistence/relations/projects.rb
@@ -9,6 +9,7 @@ module Persistence
         attribute :intro, Types::Strict::String
         attribute :body, Types::String.optional
         attribute :slug, Types::Strict::String
+        attribute :color, Types::Strict::String
         attribute :status, Types::Strict::String
         attribute :published_at, Types::Time.optional
         attribute :case_study, Types::Strict::Bool

--- a/lib/tasks/color_tasks.rake
+++ b/lib/tasks/color_tasks.rake
@@ -1,0 +1,15 @@
+namespace :color_tasks do
+  task :environment do
+    require_relative "../../component/boot"
+  end
+
+  desc "Apply colors to existing projects"
+  task :colorize_projects => :environment do
+    project_color_picker = Admin::Container["admin.persistence.post_color_picker"]
+    projects = Admin::Container["admin.persistence.repositories.projects"]
+
+    projects.listing.each do |project|
+      projects.update(project[:id], color: project_color_picker.())
+    end
+  end
+end

--- a/spec/main/shared/app/main_projects.rb
+++ b/spec/main/shared/app/main_projects.rb
@@ -11,7 +11,8 @@ RSpec.shared_context "main_projects" do
       tags: "tag",
       slug: title.to_slug.normalize.to_s,
       status: status,
-      published_at: Time.now
+      published_at: Time.now,
+      color: "blue"
     })
   end
 end


### PR DESCRIPTION
This PR adds color to project entities much in the same way that we do for posts.

![colored_work](https://cloud.githubusercontent.com/assets/479627/16224038/a2e18566-37e3-11e6-94e5-3c76fdbecf0d.gif)

We also have a task to reassign colors for all projects `rake color_tasks:colorize_projects`