### PR TITLE
Provide separate asset read and link URLs

### DIFF
--- a/component/berg/assets.rb
+++ b/component/berg/assets.rb
@@ -5,34 +5,42 @@ module Berg
     attr_reader :root
     attr_reader :precompiled
     attr_reader :precompiled_host
-    attr_reader :server_url
+    attr_reader :server_link_url
+    attr_reader :server_read_url
 
     def self.new(container = Berg::Container)
       super(
         root: container.config.root,
         precompiled: container["config"].precompiled_assets,
         precompiled_host: container["config"].precompiled_assets_host,
-        server_url: container["config"].assets_server_url,
+        server_link_url: container["config"].assets_server_link_url,
+        server_read_url: container["config"].assets_server_read_url,
       )
     end
 
-    def initialize(root:, precompiled:, precompiled_host: nil, server_url: nil)
+    def initialize(root:, precompiled:, precompiled_host: nil, server_link_url: nil, server_read_url: nil)
       @root = root
       @precompiled = precompiled
       @precompiled_host = precompiled_host
-      @server_url = server_url
+      @server_link_url = server_link_url
+      @server_read_url = server_read_url
     end
 
     def [](asset)
       if precompiled
         asset_path_from_manifest(asset)
       else
-        asset_path_on_server(asset)
+        asset_path_on_server_for_link(asset)
       end
     end
 
     def read(asset)
-      path = self[asset]
+      path =
+        if precompiled
+          asset_path_from_manifest(asset)
+        else
+          asset_path_on_server_for_read(asset)
+        end
       uri = begin
         URI(path)
       rescue URI::InvalidURIError
@@ -56,8 +64,12 @@ module Berg
       end
     end
 
-    def asset_path_on_server(asset)
-      "#{server_url}/assets/#{asset}"
+    def asset_path_on_server_for_link(asset)
+      "#{server_link_url}/assets/#{asset}"
+    end
+
+    def asset_path_on_server_for_read(asset)
+      "#{server_read_url}/assets/#{asset}"
     end
 
     def manifest

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -1,7 +1,8 @@
 development: &base
   session_secret: xxx
   database_url: "postgres://localhost/berg_development"
-  assets_server_url: "http://localhost:8080"
+  assets_server_link_url: "http://localhost:8080"
+  assets_server_read_url: "http://localhost:8080"
   admin_url: "http://localhost:3000/admin"
   canonical_domain: "http://localhost:3000"
   precompiled_assets: false

--- a/config/application.travisci.yml
+++ b/config/application.travisci.yml
@@ -1,7 +1,8 @@
 development: &base
   session_secret: xxx
   database_url: "postgres://localhost/berg_development"
-  assets_server_url: "http://localhost:8080"
+  assets_server_link_url: "http://localhost:8080"
+  assets_server_read_url: "http://localhost:8080"
   admin_url: "http://localhost:3000/admin"
   canonical_domain: "http://localhost:3000"
   precompiled_assets: true

--- a/lib/berg/config.rb
+++ b/lib/berg/config.rb
@@ -12,7 +12,8 @@ module Berg
     attribute :session_secret, RequiredString
 
     attribute :canonical_domain, Types::String
-    attribute :assets_server_url, Types::String
+    attribute :assets_server_link_url, Types::String
+    attribute :assets_server_read_url, Types::String
     attribute :precompiled_assets, Types::Form::Bool # TODO: add .default(false) when dry-types allows it
     attribute :precompiled_assets_host, Types::String
 


### PR DESCRIPTION
This makes it possible to run locally in a Docker container, where the link and read URLs need to be different.