### PR TITLE
Clear access token when a user successfully sets/resets their password

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,4 +67,5 @@ group :test do
   gem "poltergeist"
   gem "rspec"
   gem "site_prism"
+  gem "timecop"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,6 +313,7 @@ GEM
     terminal-table (1.6.0)
     thor (0.19.1)
     tilt (2.0.5)
+    timecop (0.8.1)
     unicode-display_width (1.1.0)
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
@@ -374,6 +375,7 @@ DEPENDENCIES
   site_prism
   sitemap_generator
   slim
+  timecop
   transproc!
 
 RUBY VERSION

--- a/apps/admin/lib/admin/entities/user.rb
+++ b/apps/admin/lib/admin/entities/user.rb
@@ -7,8 +7,8 @@ module Admin
       attribute :name, Types::Strict::String
       attribute :email, Types::Strict::String
       attribute :encrypted_password, Types::Nil | Types::Strict::String
-      attribute :access_token, Types::Strict::String
-      attribute :access_token_expiration, Types::Strict::Time
+      attribute :access_token, Types::Nil | Types::Strict::String
+      attribute :access_token_expiration, Types::Nil | Types::Strict::Time
       attribute :active, Types::Strict::Bool
 
       alias_method :active?, :active

--- a/apps/admin/lib/admin/persistence/repositories/users.rb
+++ b/apps/admin/lib/admin/persistence/repositories/users.rb
@@ -23,7 +23,7 @@ module Admin
 
         def by_access_token(token)
           users
-            .by_access_token(token) { access_token_expiration > Time.now }
+            .by_access_token(token)
             .as(Entities::User).one
         end
 

--- a/apps/admin/lib/admin/users/access_token.rb
+++ b/apps/admin/lib/admin/users/access_token.rb
@@ -8,7 +8,7 @@ module Admin
       end
 
       def expires_at
-        Time.now + 2.days
+        Time.now + (2*24*60*60)
       end
     end
   end

--- a/apps/admin/lib/admin/users/access_token.rb
+++ b/apps/admin/lib/admin/users/access_token.rb
@@ -8,7 +8,7 @@ module Admin
       end
 
       def expires_at
-        Time.now + 2
+        Time.now + 2.days
       end
     end
   end

--- a/apps/admin/lib/admin/users/access_token.rb
+++ b/apps/admin/lib/admin/users/access_token.rb
@@ -8,7 +8,7 @@ module Admin
       end
 
       def expires_at
-        Time.now + (2*24*60*60)
+        Time.now + (2 * 24 * 60 * 60)
       end
     end
   end

--- a/apps/admin/lib/admin/users/operations/change_password.rb
+++ b/apps/admin/lib/admin/users/operations/change_password.rb
@@ -28,7 +28,11 @@ module Admin
         private
 
         def prepare_attributes(attributes)
-          {encrypted_password: encrypt_password.(attributes[:password])}
+          {
+            encrypted_password: encrypt_password.(attributes[:password]),
+            access_token: nil,
+            access_token_expiration: nil
+          }
         end
       end
     end

--- a/db/migrate/20160906151216_change_users_access_token_null.rb
+++ b/db/migrate/20160906151216_change_users_access_token_null.rb
@@ -1,0 +1,8 @@
+ROM::SQL.migration do
+  change do
+    alter_table(:users) do
+      set_column_allow_null :access_token
+      set_column_allow_null :access_token_expiration
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,12 +2,16 @@
 -- PostgreSQL database dump
 --
 
+-- Dumped from database version 9.5.2
+-- Dumped by pg_dump version 9.5.2
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
+SET row_security = off;
 
 --
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
@@ -44,7 +48,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: about_page_people; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: about_page_people; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE about_page_people (
@@ -54,7 +58,7 @@ CREATE TABLE about_page_people (
 
 
 --
--- Name: categories; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: categories; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE categories (
@@ -84,7 +88,7 @@ ALTER SEQUENCE categories_id_seq OWNED BY categories.id;
 
 
 --
--- Name: categorisations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: categorisations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE categorisations (
@@ -114,7 +118,7 @@ ALTER SEQUENCE categorisations_id_seq OWNED BY categorisations.id;
 
 
 --
--- Name: curated_posts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: curated_posts; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE curated_posts (
@@ -152,7 +156,7 @@ ALTER SEQUENCE curated_posts_id_seq OWNED BY curated_posts.id;
 
 
 --
--- Name: home_page_featured_items; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: home_page_featured_items; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE home_page_featured_items (
@@ -186,7 +190,7 @@ ALTER SEQUENCE home_page_featured_items_id_seq OWNED BY home_page_featured_items
 
 
 --
--- Name: office_contact_details; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: office_contact_details; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE office_contact_details (
@@ -220,7 +224,7 @@ ALTER SEQUENCE office_contact_details_id_seq OWNED BY office_contact_details.id;
 
 
 --
--- Name: people; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: people; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE people (
@@ -258,7 +262,7 @@ ALTER SEQUENCE people_id_seq OWNED BY people.id;
 
 
 --
--- Name: posts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: posts; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE posts (
@@ -298,7 +302,7 @@ ALTER SEQUENCE posts_id_seq OWNED BY posts.id;
 
 
 --
--- Name: projects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: projects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE projects (
@@ -341,7 +345,7 @@ ALTER SEQUENCE projects_id_seq OWNED BY projects.id;
 
 
 --
--- Name: que_jobs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: que_jobs; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE que_jobs (
@@ -383,7 +387,7 @@ ALTER SEQUENCE que_jobs_job_id_seq OWNED BY que_jobs.job_id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE schema_migrations (
@@ -392,15 +396,15 @@ CREATE TABLE schema_migrations (
 
 
 --
--- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE users (
     id integer NOT NULL,
     email text NOT NULL,
     encrypted_password text,
-    access_token text NOT NULL,
-    access_token_expiration timestamp without time zone NOT NULL,
+    access_token text,
+    access_token_expiration timestamp without time zone,
     active boolean DEFAULT true NOT NULL,
     created_at timestamp without time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
     updated_at timestamp without time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
@@ -428,7 +432,7 @@ ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
 --
--- Name: work_page_featured_items; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: work_page_featured_items; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE work_page_featured_items (
@@ -539,7 +543,7 @@ ALTER TABLE ONLY work_page_featured_items ALTER COLUMN id SET DEFAULT nextval('w
 
 
 --
--- Name: about_page_people_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: about_page_people_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY about_page_people
@@ -547,7 +551,7 @@ ALTER TABLE ONLY about_page_people
 
 
 --
--- Name: categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY categories
@@ -555,7 +559,7 @@ ALTER TABLE ONLY categories
 
 
 --
--- Name: categorisations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: categorisations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY categorisations
@@ -563,7 +567,7 @@ ALTER TABLE ONLY categorisations
 
 
 --
--- Name: curated_posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: curated_posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY curated_posts
@@ -571,7 +575,7 @@ ALTER TABLE ONLY curated_posts
 
 
 --
--- Name: home_page_featured_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: home_page_featured_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY home_page_featured_items
@@ -579,7 +583,7 @@ ALTER TABLE ONLY home_page_featured_items
 
 
 --
--- Name: office_contact_details_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: office_contact_details_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY office_contact_details
@@ -587,7 +591,7 @@ ALTER TABLE ONLY office_contact_details
 
 
 --
--- Name: people_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: people_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY people
@@ -595,7 +599,7 @@ ALTER TABLE ONLY people
 
 
 --
--- Name: posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY posts
@@ -603,7 +607,7 @@ ALTER TABLE ONLY posts
 
 
 --
--- Name: posts_slug_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: posts_slug_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY posts
@@ -611,7 +615,7 @@ ALTER TABLE ONLY posts
 
 
 --
--- Name: projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY projects
@@ -619,7 +623,7 @@ ALTER TABLE ONLY projects
 
 
 --
--- Name: projects_slug_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: projects_slug_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY projects
@@ -627,7 +631,7 @@ ALTER TABLE ONLY projects
 
 
 --
--- Name: que_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: que_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY que_jobs
@@ -635,7 +639,7 @@ ALTER TABLE ONLY que_jobs
 
 
 --
--- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY schema_migrations
@@ -643,7 +647,7 @@ ALTER TABLE ONLY schema_migrations
 
 
 --
--- Name: users_email_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: users_email_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users
@@ -651,7 +655,7 @@ ALTER TABLE ONLY users
 
 
 --
--- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users
@@ -659,7 +663,7 @@ ALTER TABLE ONLY users
 
 
 --
--- Name: work_page_featured_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: work_page_featured_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY work_page_featured_items

--- a/lib/persistence/relations/users.rb
+++ b/lib/persistence/relations/users.rb
@@ -7,8 +7,8 @@ module Persistence
         attribute :name, Types::Strict::String
         attribute :encrypted_password, Types::Strict::String.optional
         attribute :active, Types::Strict::Bool
-        attribute :access_token, Types::Strict::String
-        attribute :access_token_expiration, Types::Strict::Time
+        attribute :access_token, Types::Strict::String.optional
+        attribute :access_token_expiration, Types::Strict::Time.optional
       end
 
       def by_id(id)
@@ -20,7 +20,7 @@ module Persistence
       end
 
       def by_access_token(token)
-        where(access_token: token)
+        where("access_token = ? AND access_token_expiration > ?", token, Time.now)
       end
 
       def active

--- a/spec/admin/features/activation_spec.rb
+++ b/spec/admin/features/activation_spec.rb
@@ -3,6 +3,10 @@ require "admin_app_helper"
 RSpec.feature "Admin / Activation", js: true do
   include_context "admin users"
 
+  before do
+    Timecop.freeze(Time.now)
+  end
+
   scenario "I can activate my account by setting my password" do
     visit("/admin/reset-password/#{jane.access_token}")
 
@@ -25,6 +29,16 @@ RSpec.feature "Admin / Activation", js: true do
 
   scenario "I am redirected to sign-in page when token is not valid" do
     visit("/admin/reset-password/not-good")
+
+    expect(page).to have_content("Token is invalid or expired")
+    expect(page).to have_content("Sign in")
+  end
+
+  scenario "I am redirected to sign-in page when token has expired" do
+    # Tokens are valid for two days, so advance 3 days
+    Timecop.travel(Time.now + 3 * 24 * 60 * 60)
+
+    visit("/admin/reset-password/#{jane.access_token}")
 
     expect(page).to have_content("Token is invalid or expired")
     expect(page).to have_content("Sign in")

--- a/spec/admin/features/activation_spec.rb
+++ b/spec/admin/features/activation_spec.rb
@@ -1,6 +1,6 @@
 require "admin_app_helper"
 
-RSpec.feature "Admin / Users / Activation", js: true do
+RSpec.feature "Admin / Activation", js: true do
   include_context "admin users"
 
   scenario "I can activate my account by setting my password" do
@@ -28,5 +28,22 @@ RSpec.feature "Admin / Users / Activation", js: true do
 
     expect(page).to have_content("Token is invalid or expired")
     expect(page).to have_content("Sign in")
+  end
+
+  scenario "The access token is cleared when my password is set successfully" do
+    visit("/admin/reset-password/#{jane.access_token}")
+
+    find("#password").set("super-secret")
+    find("button", text: "Save").trigger("click")
+
+    expect(page).to have_content("Your password has been set")
+
+    find("nav a", text: "Log out").trigger("click")
+
+    expect(page).to have_content("You are now signed out")
+
+    visit("/admin/reset-password/#{jane.access_token}")
+
+    expect(page).to have_content("Token is invalid or expired")
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 
 require "byebug"
+require "timecop"
 
 ENV["RACK_ENV"] = "test"
 


### PR DESCRIPTION
I've fixed an issue for MUP today (https://github.com/icelab/mup/issues/23) that is also an issue here so I figured I'd go ahead and knock it over here too. 

In a nutshell, currently password reset `access_tokens` are able to be reused and the associated `access_token_expiration` timestamp isn't taken into account when using the token to retrieve a user. 

This PR addresses both of these issues:
- `access_token` and `access_token_expiration` are both cleared when a user successfully sets/resets their password
- Expiry of access tokens is now enforced, by modifying the `#by_access_token` method in the users relation like so:
```
def by_access_token(token)
  where("access_token = ? AND access_token_expiration > ?", token, Time.now)
end
```