### PR TITLE
Replace attache URLs in decorator output

### DIFF
--- a/apps/main/lib/main/decorators/public_post.rb
+++ b/apps/main/lib/main/decorators/public_post.rb
@@ -66,7 +66,7 @@ module Main
 
       def to_html(input)
         renderer = Redcarpet::Markdown.new(StandardRenderer, footnotes: true, hard_wrap: true, fenced_code_blocks: true, tables: true, no_intra_emphasis: true)
-        renderer.render(input)
+        replace_attache_urls(renderer.render(input))
       end
 
       def single_line_markdown(input)

--- a/apps/main/lib/main/decorators/public_project.rb
+++ b/apps/main/lib/main/decorators/public_project.rb
@@ -35,7 +35,7 @@ module Main
 
       def to_html(input)
         renderer = Redcarpet::Markdown.new(StandardRenderer, footnotes: true, hard_wrap: true, tables: true, no_intra_emphasis: true)
-        renderer.render(input)
+        replace_attache_urls(renderer.render(input))
       end
 
       def single_line_markdown(input)

--- a/lib/berg/decorator.rb
+++ b/lib/berg/decorator.rb
@@ -14,5 +14,9 @@ module Berg
       prefix, basename = File.split(file_path)
       [Berg::Container["config"].attache_downloads_base_url, "view", prefix, CGI.escape(geometry), CGI.escape(basename)].join("/")
     end
+
+    def replace_attache_urls(str)
+      str.gsub(/#{Berg::Container["config"].attache_uploads_base_url}/, Berg::Container["config"].attache_downloads_base_url)
+    end
   end
 end


### PR DESCRIPTION
Add method to the decorator to replace stray attache upload URLs with their download URL equivalent.

This is needed because the upload field currently returns the upload URL on initial upload, and so that is exposed to the user until they reload the page.