### PR TITLE
Remove `notes` reference from `Newer/Older` pagination links

### DIFF
--- a/apps/main/lib/main/decorators/public_post.rb
+++ b/apps/main/lib/main/decorators/public_post.rb
@@ -66,7 +66,7 @@ module Main
 
       def to_html(input)
         renderer = Redcarpet::Markdown.new(StandardRenderer, footnotes: true, hard_wrap: true, fenced_code_blocks: true, tables: true, no_intra_emphasis: true)
-        renderer.render(input)
+        replace_attache_urls(renderer.render(input))
       end
 
       def single_line_markdown(input)

--- a/apps/main/lib/main/decorators/public_project.rb
+++ b/apps/main/lib/main/decorators/public_project.rb
@@ -35,7 +35,7 @@ module Main
 
       def to_html(input)
         renderer = Redcarpet::Markdown.new(StandardRenderer, footnotes: true, hard_wrap: true, tables: true, no_intra_emphasis: true)
-        renderer.render(input)
+        replace_attache_urls(renderer.render(input))
       end
 
       def single_line_markdown(input)

--- a/apps/main/web/templates/shared/_pager_links.html.slim
+++ b/apps/main/web/templates/shared/_pager_links.html.slim
@@ -4,7 +4,7 @@
     i &larr;
     em Newer
 - else
-  a.notes-newer href="/notes?page=#{prev_page}" rel="prev"
+  a.notes-newer href="?page=#{prev_page}" rel="prev"
     i &larr;
     em Newer
 
@@ -14,6 +14,6 @@
     em Older
     i &rarr;
 - else
-  a.notes-older href="/notes?page=#{next_page}" rel="next"
+  a.notes-older href="?page=#{next_page}" rel="next"
     em Older
     i &rarr;

--- a/lib/berg/decorator.rb
+++ b/lib/berg/decorator.rb
@@ -14,5 +14,9 @@ module Berg
       prefix, basename = File.split(file_path)
       [Berg::Container["config"].attache_downloads_base_url, "view", prefix, CGI.escape(geometry), CGI.escape(basename)].join("/")
     end
+
+    def replace_attache_urls(str)
+      str.gsub(/#{Berg::Container["config"].attache_uploads_base_url}/, Berg::Container["config"].attache_downloads_base_url)
+    end
   end
 end


### PR DESCRIPTION
Otherwise links always point at `/notes?page=x` even if we're inside the sub-category (i.e. https://www.icelab.com.au/notes/category/ruby)