### PR TITLE
Search posts in admin area

### DIFF
--- a/apps/admin/assets/admin/utilities/index.css
+++ b/apps/admin/assets/admin/utilities/index.css
@@ -25,3 +25,8 @@
 .vertical-align--bottom {
   vertical-align: bottom;
 }
+
+.form-fields input {
+  width: 25rem;
+  height: 3rem;
+}

--- a/apps/admin/lib/admin/persistence/repositories/posts.rb
+++ b/apps/admin/lib/admin/persistence/repositories/posts.rb
@@ -42,6 +42,15 @@ module Admin
             .as(Entities::Post)
         end
 
+        def search(query: nil, per_page: 20, page: 1)
+          posts
+            .search(query)
+            .per_page(per_page)
+            .page(page)
+            .order(Sequel.desc(:published_at))
+            .as(Entities::Post)
+        end
+
         def recent_colors
           posts
             .select(:color)

--- a/apps/admin/lib/admin/views/posts/edit.rb
+++ b/apps/admin/lib/admin/views/posts/edit.rb
@@ -23,6 +23,7 @@ module Admin
 
           super.merge(
             post: post,
+            query: nil,
             form: post_form(post, validation)
           )
         end

--- a/apps/admin/lib/admin/views/posts/index.rb
+++ b/apps/admin/lib/admin/views/posts/index.rb
@@ -21,6 +21,7 @@ module Admin
 
           super.merge(
             posts: admin_posts,
+            query: nil,
             paginator: Paginator.new(all_posts.pager, url_template: "/admin/posts?page=%")
           )
         end

--- a/apps/admin/lib/admin/views/posts/new.rb
+++ b/apps/admin/lib/admin/views/posts/new.rb
@@ -12,7 +12,10 @@ module Admin
         end
 
         def locals(options = {})
-          super.merge(form: form_data(options[:validation]))
+          super.merge(
+            query: nil,
+            form: form_data(options[:validation])
+          )
         end
 
         def form_data(validation)

--- a/apps/admin/lib/admin/views/posts/search.rb
+++ b/apps/admin/lib/admin/views/posts/search.rb
@@ -1,0 +1,32 @@
+require "admin/import"
+require "admin/paginator"
+require "admin/view"
+
+module Admin
+  module Views
+    module Posts
+      class Search < Admin::View
+        include Admin::Import["persistence.repositories.posts"]
+
+        configure do |config|
+          config.template = "posts/index"
+        end
+
+        def locals(options = {})
+          page      = options[:page] || 1
+          per_page  = options[:per_page] || 20
+          query  = options[:query] || ""
+
+          all_posts = posts.search(query: query, page: page, per_page: per_page)
+          admin_posts = Decorators::Post.decorate(all_posts)
+
+          super.merge(
+            posts: admin_posts,
+            query: options[:query],
+            paginator: Paginator.new(all_posts.pager, url_template: "/admin/posts?page=%")
+          )
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/web/routes/posts.rb
+++ b/apps/admin/web/routes/posts.rb
@@ -22,6 +22,10 @@ class Admin::Application
         end
       end
 
+      r.get "search" do
+        r.view "posts.search", page: r[:page], query: r[:q]
+      end
+
       r.get "new" do
         r.view "posts.new"
       end

--- a/apps/admin/web/templates/posts/_actions.html.slim
+++ b/apps/admin/web/templates/posts/_actions.html.slim
@@ -1,1 +1,5 @@
+form.fl-right.ml-xlarge action="/admin/posts/search" method="GET"
+  div.form-fields
+    input.form-input type="search" name="q" placeholder="Search Posts" value=query
+    button.fl-right.button.button--primary.button--small Go
 a.fl-right.button.button--primary.button--small href="/admin/posts/new" Add a post

--- a/spec/admin/features/posts/search_spec.rb
+++ b/spec/admin/features/posts/search_spec.rb
@@ -1,0 +1,51 @@
+require "admin_app_helper"
+
+RSpec.feature "Admin / Posts / Search", js: true do
+  include_context "admin people"
+  include_context "admin users"
+  include_context "admin posts"
+
+  background do
+    sign_in(jane.email, jane.password)
+  end
+
+  scenario "I can search for a post by text in its title" do
+    searchable_post =  create_post("Searchable post title")
+
+    visit "/admin/posts"
+
+    find(:css, "input[type='search']").set("Search")
+    find("button", text: "Go").trigger("click")
+
+    expect(page).to have_content(searchable_post.title)
+    expect(page).to_not have_content(sample_post.title)
+  end
+
+  scenario "I can search for a post by text in its body" do
+    searchable_post =  create_post("Searchable post title", body: "Lorem ipsum and such")
+
+    visit "/admin/posts"
+
+    find(:css, "input[type='search']").set("such")
+    find("button", text: "Go").trigger("click")
+
+    expect(page).to have_content(searchable_post.title)
+    expect(page).to_not have_content(sample_post.title)
+  end
+
+  scenario "Found posts are weigted by their title" do
+    first_post =  create_post("lorem lorem lorem bar")
+    second_post =  create_post("lorem lorem bar bar")
+
+    visit "/admin/posts"
+
+    find(:css, "input[type='search']").set("lorem")
+    find("button", text: "Go").trigger("click")
+
+    sleep 1 #because page load ¯\_(ツ)_/¯
+
+    found_titles = page.all(:css, "tr > td > a").map(&:text)
+
+    expect(found_titles).to eq([first_post.title, second_post.title])
+  end
+end


### PR DESCRIPTION
This PR adds search to posts in the admin area. 

I have been wanting to take a look at full text search with Postgres for a while and thought this would be a good addition to the admin area.

<img width="1255" alt="screen shot 2016-11-12 at 4 57 37 pm" src="https://cloud.githubusercontent.com/assets/479627/20236030/b9505dcc-a8f9-11e6-99d5-3064ac56bce9.png">

Source: http://rachbelaid.com/postgres-full-text-search-is-good-enough/