### PR TITLE
Cross post to medium

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem "transproc", git: "https://github.com/solnic/transproc"
 
 # 3rd party services
 gem "bugsnag"
+gem "medium-sdk-ruby"
 gem "postmark"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,9 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    hurley (0.2)
+    hurley-http-cache (0.1.0)
+      hurley (~> 0.1, >= 0.1)
     i18n (0.7.0)
     ice_nine (0.11.2)
     inflecto (0.0.2)
@@ -185,6 +188,9 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
     lumberjack (1.0.10)
+    medium-sdk-ruby (1.0.2)
+      hurley (~> 0.0)
+      hurley-http-cache (~> 0.1)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -352,6 +358,7 @@ DEPENDENCIES
   guard-rspec
   i18n
   inflecto
+  medium-sdk-ruby
   mime-types
   notgun
   pg

--- a/apps/admin/assets/admin/expandable/index.css
+++ b/apps/admin/assets/admin/expandable/index.css
@@ -1,0 +1,25 @@
+[data-view-expandable] {
+  position: relative;
+}
+
+[data-view-expandable] li ul {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 3rem;
+  background: #fff;
+  border: 0.1rem solid #eaeaea;
+  width: 15rem;
+  z-index: 2;
+}
+
+[data-view-expandable] li ul li {
+  padding: 1rem;
+  border-bottom: 0.1rem solid #eaeaea;
+}
+
+[data-view-expandable] li.expanded ul {
+  display: inline;
+}
+
+

--- a/apps/admin/assets/admin/expandable/index.js
+++ b/apps/admin/assets/admin/expandable/index.js
@@ -1,0 +1,5 @@
+export default function (el, props) {
+  el.addEventListener('click', function (e) {
+    el.querySelector('li[data-expandable]').classList.toggle('expanded')
+  })
+}

--- a/apps/admin/assets/admin/index.css
+++ b/apps/admin/assets/admin/index.css
@@ -6,3 +6,4 @@
 
 @import './sign-in';
 @import './utilities';
+@import './expandable';

--- a/apps/admin/assets/admin/views/index.js
+++ b/apps/admin/assets/admin/views/index.js
@@ -1,4 +1,6 @@
 /**
  * Object for holding our `viewloader` views
  */
-export default {}
+import expandable from '../expandable'
+
+export default {expandable}

--- a/apps/admin/config/locales/admin.yml
+++ b/apps/admin/config/locales/admin.yml
@@ -20,6 +20,8 @@ en:
     posts:
       post_created: "Post has been created"
       post_updated: "Post has been updated"
+      post_shared: "Post has been shared"
+      post_share_failed: "Post share failed"
     projects:
       project_created: "Project has been created"
       project_updated: "Project has been updated"

--- a/apps/admin/lib/admin/entities/post.rb
+++ b/apps/admin/lib/admin/entities/post.rb
@@ -17,6 +17,7 @@ module Admin
       attribute :published_at, Types::Strict::Time.optional
       attribute :color, Types::PostHighlightColor
       attribute :assets, Types::Coercible::Array.member(Admin::Entities::Asset).optional
+      attribute :medium_url, Types::Strict::String.optional
 
       def published?
         status == "published"

--- a/apps/admin/lib/admin/posts/operations/share/medium.rb
+++ b/apps/admin/lib/admin/posts/operations/share/medium.rb
@@ -1,0 +1,46 @@
+require "admin/import"
+require "admin/entities/post"
+require "berg/matcher"
+
+module Admin
+  module Posts
+    module Operations
+      module Share
+        class Medium
+          include Admin::Import[
+            "persistence.repositories.posts",
+            create_medium_post: "medium_client.create_post"
+          ]
+
+          include Berg::Matcher
+
+          def call(slug)
+            post = posts.by_slug!(slug)
+            medium_post = create_medium_post.(prepare_post(post))
+
+            if medium_post.success?
+              response = JSON.parse(medium_post.body)
+              posts.update_by_id(post.id, medium_url: response["data"]["url"])
+              Dry::Monads::Right(post)
+            else
+              Dry::Monads::Left(post)
+            end
+          end
+
+          private
+
+          def prepare_post(post)
+            {
+              title: post.title,
+              content_format: "html",
+              content: post.body,
+              tags: post.categories.map(&:name),
+              canonical_url: "#{Berg::Container["config"].canonical_domain}/notes/#{post.slug}",
+              publishStatus: "public"
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/apps/admin/system/admin/medium_client/create_post.rb
+++ b/apps/admin/system/admin/medium_client/create_post.rb
@@ -1,0 +1,16 @@
+require "medium"
+
+module Admin
+  module MediumClient
+    class CreatePost
+      include Admin::Import[
+        "medium_client"
+      ]
+
+      def call(post_attrs)
+        user = medium_client.users.me
+        medium_client.posts.create(user, post_attrs)
+      end
+    end
+  end
+end

--- a/apps/admin/system/boot.rb
+++ b/apps/admin/system/boot.rb
@@ -1,4 +1,5 @@
 require_relative "admin/container"
+require "medium"
 
 # Load manually registered dependencies
 Admin::Container.require "system/container/persistence"
@@ -6,6 +7,9 @@ Admin::Container.require "system/container/persistence"
 Admin::Container.finalize! do |container|
   require "admin/enqueue"
   container.register :enqueue, Admin::Enqueue.new
+  container.register :medium_client, ::Medium::Client.new(
+    integration_token: Berg::Container["config"].medium_integration_token
+  )
 end
 
 require "admin/application"

--- a/apps/admin/web/routes/posts.rb
+++ b/apps/admin/web/routes/posts.rb
@@ -31,6 +31,24 @@ class Admin::Application
           r.view "posts.edit", slug: slug
         end
 
+        r.on "share" do
+          r.post "medium" do
+            r.resolve "posts.operations.share.medium" do |share|
+              share.(slug) do |m|
+                m.success do
+                  flash[:notice] = t["admin.posts.post_shared"]
+                  r.redirect "/admin/posts"
+                end
+
+                m.failure do
+                  flash[:notice] = t["admin.posts.post_share_failed"]
+                  r.redirect "/admin/posts"
+                end
+              end
+            end
+          end
+        end
+
         r.put do
           r.resolve "posts.operations.update" do |update_post|
             update_post.(slug, r[:post]) do |m|

--- a/apps/admin/web/templates/posts/index.html.slim
+++ b/apps/admin/web/templates/posts/index.html.slim
@@ -12,6 +12,7 @@ h1.h-1 Posts
             th Status
             th Published at
             th.horizontal-align--center Actions
+            th
         tbody
           - posts.each do |post|
             tr id="post-#{post.slug}"
@@ -25,6 +26,20 @@ h1.h-1 Posts
                   = post.published_date
                 td.horizontal-align--center.vertical-align--middle
                   a href="/notes/#{post.slug}" View
+                td.horizontal-align--center.vertical-align--middle
+                  ul data-view-expandable="true"
+                    li data-expandable="true"
+                      button.button.fl-right.button.button--ghost.button--xsmall Share&hellip;
+                      ul
+                        - if post.medium_url
+                          li
+                            a href=post.medium_url View on Medium
+                        - else
+                          li
+                            form method="POST" action="/admin/posts/#{post.slug}/share/medium"
+                              ==csrf_tag
+                              button Share on Medium
+
               - else
                 td
                 td

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -21,6 +21,7 @@ development: &base
   aws_bucket: "icelab-site-production"
   aws_region: "ap-southeast-2"
   ga_tracking_id:
+  medium_integration_token: "xxx"
 test:
   <<: *base
   database_url: "postgres://localhost/berg_test"

--- a/config/application.travisci.yml
+++ b/config/application.travisci.yml
@@ -13,6 +13,7 @@ development: &base
   postmark_api_key:
   basic_auth_user:
   basic_auth_password:
+  medium_integration_token: "xxx"
 test:
   <<: *base
   database_url: "postgres://localhost/berg_test"

--- a/db/migrate/20170218031750_add_medium_url_to_posts.rb
+++ b/db/migrate/20170218031750_add_medium_url_to_posts.rb
@@ -1,0 +1,5 @@
+ROM::SQL.migration do
+  change do
+    add_column :posts, :medium_url, String, null: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,12 +2,17 @@
 -- PostgreSQL database dump
 --
 
+-- Dumped from database version 9.6.1
+-- Dumped by pg_dump version 9.6.1
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
+SET row_security = off;
 
 --
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
@@ -44,7 +49,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: about_page_people; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: about_page_people; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE about_page_people (
@@ -54,7 +59,7 @@ CREATE TABLE about_page_people (
 
 
 --
--- Name: categories; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: categories; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE categories (
@@ -84,7 +89,7 @@ ALTER SEQUENCE categories_id_seq OWNED BY categories.id;
 
 
 --
--- Name: categorisations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: categorisations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE categorisations (
@@ -114,7 +119,7 @@ ALTER SEQUENCE categorisations_id_seq OWNED BY categorisations.id;
 
 
 --
--- Name: curated_posts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: curated_posts; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE curated_posts (
@@ -152,7 +157,7 @@ ALTER SEQUENCE curated_posts_id_seq OWNED BY curated_posts.id;
 
 
 --
--- Name: home_page_featured_items; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: home_page_featured_items; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE home_page_featured_items (
@@ -186,7 +191,7 @@ ALTER SEQUENCE home_page_featured_items_id_seq OWNED BY home_page_featured_items
 
 
 --
--- Name: office_contact_details; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: office_contact_details; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE office_contact_details (
@@ -220,7 +225,7 @@ ALTER SEQUENCE office_contact_details_id_seq OWNED BY office_contact_details.id;
 
 
 --
--- Name: people; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: people; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE people (
@@ -259,7 +264,7 @@ ALTER SEQUENCE people_id_seq OWNED BY people.id;
 
 
 --
--- Name: posts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: posts; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE posts (
@@ -275,7 +280,8 @@ CREATE TABLE posts (
     teaser text DEFAULT ''::text NOT NULL,
     color text DEFAULT ''::text NOT NULL,
     cover_image json,
-    assets json
+    assets json,
+    medium_url text
 );
 
 
@@ -299,7 +305,7 @@ ALTER SEQUENCE posts_id_seq OWNED BY posts.id;
 
 
 --
--- Name: projects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: projects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE projects (
@@ -342,7 +348,7 @@ ALTER SEQUENCE projects_id_seq OWNED BY projects.id;
 
 
 --
--- Name: que_jobs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: que_jobs; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE que_jobs (
@@ -384,7 +390,7 @@ ALTER SEQUENCE que_jobs_job_id_seq OWNED BY que_jobs.job_id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE schema_migrations (
@@ -393,7 +399,7 @@ CREATE TABLE schema_migrations (
 
 
 --
--- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE users (
@@ -429,7 +435,7 @@ ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
 --
--- Name: work_page_featured_items; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: work_page_featured_items; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE work_page_featured_items (
@@ -463,84 +469,84 @@ ALTER SEQUENCE work_page_featured_items_id_seq OWNED BY work_page_featured_items
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: categories id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY categories ALTER COLUMN id SET DEFAULT nextval('categories_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: categorisations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY categorisations ALTER COLUMN id SET DEFAULT nextval('categorisations_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: curated_posts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY curated_posts ALTER COLUMN id SET DEFAULT nextval('curated_posts_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: home_page_featured_items id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY home_page_featured_items ALTER COLUMN id SET DEFAULT nextval('home_page_featured_items_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: office_contact_details id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY office_contact_details ALTER COLUMN id SET DEFAULT nextval('office_contact_details_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: people id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY people ALTER COLUMN id SET DEFAULT nextval('people_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: posts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY posts ALTER COLUMN id SET DEFAULT nextval('posts_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: projects id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY projects ALTER COLUMN id SET DEFAULT nextval('projects_id_seq'::regclass);
 
 
 --
--- Name: job_id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: que_jobs job_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY que_jobs ALTER COLUMN job_id SET DEFAULT nextval('que_jobs_job_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: work_page_featured_items id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY work_page_featured_items ALTER COLUMN id SET DEFAULT nextval('work_page_featured_items_id_seq'::regclass);
 
 
 --
--- Name: about_page_people_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: about_page_people about_page_people_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY about_page_people
@@ -548,7 +554,7 @@ ALTER TABLE ONLY about_page_people
 
 
 --
--- Name: categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: categories categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY categories
@@ -556,7 +562,7 @@ ALTER TABLE ONLY categories
 
 
 --
--- Name: categorisations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: categorisations categorisations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY categorisations
@@ -564,7 +570,7 @@ ALTER TABLE ONLY categorisations
 
 
 --
--- Name: curated_posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: curated_posts curated_posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY curated_posts
@@ -572,7 +578,7 @@ ALTER TABLE ONLY curated_posts
 
 
 --
--- Name: home_page_featured_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: home_page_featured_items home_page_featured_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY home_page_featured_items
@@ -580,7 +586,7 @@ ALTER TABLE ONLY home_page_featured_items
 
 
 --
--- Name: office_contact_details_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: office_contact_details office_contact_details_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY office_contact_details
@@ -588,7 +594,7 @@ ALTER TABLE ONLY office_contact_details
 
 
 --
--- Name: people_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: people people_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY people
@@ -596,7 +602,7 @@ ALTER TABLE ONLY people
 
 
 --
--- Name: people_slug_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: people people_slug_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY people
@@ -604,7 +610,7 @@ ALTER TABLE ONLY people
 
 
 --
--- Name: posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: posts posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY posts
@@ -612,7 +618,7 @@ ALTER TABLE ONLY posts
 
 
 --
--- Name: posts_slug_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: posts posts_slug_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY posts
@@ -620,7 +626,7 @@ ALTER TABLE ONLY posts
 
 
 --
--- Name: projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: projects projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY projects
@@ -628,7 +634,7 @@ ALTER TABLE ONLY projects
 
 
 --
--- Name: projects_slug_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: projects projects_slug_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY projects
@@ -636,7 +642,7 @@ ALTER TABLE ONLY projects
 
 
 --
--- Name: que_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: que_jobs que_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY que_jobs
@@ -644,7 +650,7 @@ ALTER TABLE ONLY que_jobs
 
 
 --
--- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY schema_migrations
@@ -652,7 +658,7 @@ ALTER TABLE ONLY schema_migrations
 
 
 --
--- Name: users_email_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: users users_email_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users
@@ -660,7 +666,7 @@ ALTER TABLE ONLY users
 
 
 --
--- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users
@@ -668,7 +674,7 @@ ALTER TABLE ONLY users
 
 
 --
--- Name: work_page_featured_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: work_page_featured_items work_page_featured_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY work_page_featured_items
@@ -676,35 +682,35 @@ ALTER TABLE ONLY work_page_featured_items
 
 
 --
--- Name: set_updated_at_on_curated_posts; Type: TRIGGER; Schema: public; Owner: -
+-- Name: curated_posts set_updated_at_on_curated_posts; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER set_updated_at_on_curated_posts BEFORE UPDATE ON curated_posts FOR EACH ROW EXECUTE PROCEDURE set_updated_at_column();
 
 
 --
--- Name: set_updated_at_on_people; Type: TRIGGER; Schema: public; Owner: -
+-- Name: people set_updated_at_on_people; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER set_updated_at_on_people BEFORE UPDATE ON people FOR EACH ROW EXECUTE PROCEDURE set_updated_at_column();
 
 
 --
--- Name: set_updated_at_on_posts; Type: TRIGGER; Schema: public; Owner: -
+-- Name: posts set_updated_at_on_posts; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER set_updated_at_on_posts BEFORE UPDATE ON posts FOR EACH ROW EXECUTE PROCEDURE set_updated_at_column();
 
 
 --
--- Name: set_updated_at_on_projects; Type: TRIGGER; Schema: public; Owner: -
+-- Name: projects set_updated_at_on_projects; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER set_updated_at_on_projects BEFORE UPDATE ON projects FOR EACH ROW EXECUTE PROCEDURE set_updated_at_column();
 
 
 --
--- Name: set_updated_at_on_users; Type: TRIGGER; Schema: public; Owner: -
+-- Name: users set_updated_at_on_users; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER set_updated_at_on_users BEFORE UPDATE ON users FOR EACH ROW EXECUTE PROCEDURE set_updated_at_column();

--- a/lib/berg/config.rb
+++ b/lib/berg/config.rb
@@ -35,6 +35,7 @@ module Berg
     attribute :aws_region, Types::String
 
     attribute :ga_tracking_id, Types::String
+    attribute :medium_integration_token, Types::String
 
     def self.load(root, name, env)
       path = root.join("config").join("#{name}.yml")

--- a/lib/persistence/relations/posts.rb
+++ b/lib/persistence/relations/posts.rb
@@ -13,6 +13,7 @@ module Persistence
         attribute :person_id, Types::ForeignKey(:people)
         attribute :published_at, Types::Strict::Time.optional
         attribute :assets, Types::JSON
+        attribute :medium_url, Types::Strict::String
 
         associations do
           belongs_to :person, as: :author


### PR DESCRIPTION
This PR aims to tackle #122.

Cross posting directly from the create form would mean that typos would make it to Medium and editing them would be tedious. So I have added a share context menu next to each post that will show a link to the post on Medium once the post is shared there. This way, we can also expand out to other services if we need.

Todo 
- [ ] Test with embedded images

<img width="1243" alt="screen shot 2017-02-18 at 6 45 09 pm" src="https://cloud.githubusercontent.com/assets/479627/23091537/9e70f9b6-f60c-11e6-8458-b083e75f3294.png">
