### PR TITLE
Use the attache builder to render inline images

### DIFF
--- a/apps/main/lib/main/renderers/standard_renderer.rb
+++ b/apps/main/lib/main/renderers/standard_renderer.rb
@@ -84,10 +84,14 @@ class StandardRenderer < Redcarpet::Render::HTML
   end
 
   def resize_image(link, geometry)
+    link_url = URI(link)
+    path = link_url.path
+      .gsub(/\/view\//, "")
+      .gsub(/\/original/, "")
     if geometry
-      link.gsub(/\/original\//, "/#{geometry.to_s}/")
+      attache_url_builder.url(path, [:resize, geometry])
     else
-      link
+      attache_url_builder.url(path)
     end
   end
 
@@ -154,6 +158,12 @@ class StandardRenderer < Redcarpet::Render::HTML
     output << "</div>"
     output << "</figure>"
     output.join("")
+  end
+
+  private
+
+  def attache_url_builder
+    Berg::Container["attache.builder"]
   end
 end
 

--- a/apps/main/lib/main/renderers/standard_renderer.rb
+++ b/apps/main/lib/main/renderers/standard_renderer.rb
@@ -91,7 +91,7 @@ class StandardRenderer < Redcarpet::Render::HTML
     if geometry
       attache_url_builder.url(path, [:resize, geometry])
     else
-      attache_url_builder.url(path)
+      attache_url_builder.original_url(path)
     end
   end
 


### PR DESCRIPTION
A quick fix for the places we’re rewriting images to work with the new signed attache URLs.